### PR TITLE
fix: error propagation;

### DIFF
--- a/bindings/nodejs/src/decision.rs
+++ b/bindings/nodejs/src/decision.rs
@@ -41,7 +41,8 @@ impl JsZenDecision {
             ))
         })
         .await
-        .map_err(|_| anyhow!("Hook timed out"))??;
+        .map_err(|_| anyhow!("Hook timed out"))?
+        .map_err(|e| anyhow!(e))?;
 
         Ok(serde_json::to_value(&result)?)
     }

--- a/bindings/nodejs/src/engine.rs
+++ b/bindings/nodejs/src/engine.rs
@@ -73,7 +73,8 @@ impl JsZenEngine {
             ))
         })
         .await
-        .map_err(|_| anyhow!("Hook timed out"))??;
+        .map_err(|_| anyhow!("Hook timed out"))?
+        .map_err(|e| anyhow!(e))?;
 
         Ok(serde_json::to_value(&result)?)
     }

--- a/bindings/nodejs/src/loader.rs
+++ b/bindings/nodejs/src/loader.rs
@@ -39,7 +39,7 @@ impl JsDecisionLoader {
           return Err(LoaderError::Internal {
               key: key.to_string(),
               source: anyhow!("Loader is undefined")
-          })
+          }.into())
         };
 
         let promise: Promise<Option<Buffer>> =
@@ -57,7 +57,7 @@ impl JsDecisionLoader {
         })?;
 
         let Some(buffer) = result else {
-            return Err(LoaderError::NotFound(key.to_string()));
+            return Err(LoaderError::NotFound(key.to_string()).into());
         };
 
         let decision_content =

--- a/bindings/python/src/loader.rs
+++ b/bindings/python/src/loader.rs
@@ -32,9 +32,12 @@ impl PyDecisionLoader {
 #[async_trait]
 impl DecisionLoader for PyDecisionLoader {
     async fn load(&self, key: &str) -> LoaderResult<Arc<DecisionContent>> {
-        self.load_element(key).map_err(|e| LoaderError::Internal {
-            source: e,
-            key: key.to_string(),
+        self.load_element(key).map_err(|e| {
+            LoaderError::Internal {
+                source: e,
+                key: key.to_string(),
+            }
+            .into()
         })
     }
 }

--- a/core/engine/src/engine.rs
+++ b/core/engine/src/engine.rs
@@ -169,6 +169,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(miri, ignore)]
     fn it_throws_correct_error_type() {
         let cargo_root = Path::new(env!("CARGO_MANIFEST_DIR"));
         let test_data_root = cargo_root.join("../../").join("test-data");

--- a/core/engine/src/error.rs
+++ b/core/engine/src/error.rs
@@ -1,0 +1,42 @@
+use crate::handler::node::NodeError;
+use crate::loader::LoaderError;
+use thiserror::Error;
+
+#[derive(Debug, Error)]
+pub enum EvaluationError {
+    #[error("Loader error")]
+    LoaderError(Box<LoaderError>),
+
+    #[error("Node error")]
+    NodeError(Box<NodeError>),
+
+    #[error("Depth limit exceeded")]
+    DepthLimitExceeded,
+
+    #[error("Node not found {0}")]
+    NodeConnectError(String),
+}
+
+impl From<LoaderError> for Box<EvaluationError> {
+    fn from(error: LoaderError) -> Self {
+        Box::new(EvaluationError::LoaderError(error.into()))
+    }
+}
+
+impl From<Box<LoaderError>> for Box<EvaluationError> {
+    fn from(error: Box<LoaderError>) -> Self {
+        Box::new(EvaluationError::LoaderError(error))
+    }
+}
+
+impl From<NodeError> for Box<EvaluationError> {
+    fn from(error: NodeError) -> Self {
+        Box::new(EvaluationError::NodeError(error.into()))
+    }
+}
+
+impl From<Box<NodeError>> for Box<EvaluationError> {
+    fn from(error: Box<NodeError>) -> Self {
+        Box::new(EvaluationError::NodeError(error))
+    }
+}

--- a/core/engine/src/lib.rs
+++ b/core/engine/src/lib.rs
@@ -124,6 +124,7 @@
 
 mod decision;
 mod engine;
+mod error;
 mod handler;
 
 pub mod loader;
@@ -132,3 +133,5 @@ pub mod model;
 
 pub use decision::Decision;
 pub use engine::{DecisionEngine, EvaluationOptions};
+pub use error::EvaluationError;
+pub use handler::node::NodeError;

--- a/core/engine/src/loader/filesystem.rs
+++ b/core/engine/src/loader/filesystem.rs
@@ -54,7 +54,7 @@ impl FilesystemLoader {
 
         let path = self.key_to_path(key.as_ref());
         if !Path::exists(&path) {
-            return Err(LoaderError::NotFound(String::from(key.as_ref())));
+            return Err(LoaderError::NotFound(String::from(key.as_ref())).into());
         }
 
         let file = File::open(path).map_err(|e| LoaderError::Internal {

--- a/core/engine/src/loader/memory.rs
+++ b/core/engine/src/loader/memory.rs
@@ -41,6 +41,6 @@ impl MemoryLoader {
 impl DecisionLoader for MemoryLoader {
     async fn load(&self, key: &str) -> LoaderResponse {
         self.get(&key)
-            .ok_or_else(|| LoaderError::NotFound(key.to_string()))
+            .ok_or_else(|| LoaderError::NotFound(key.to_string()).into())
     }
 }

--- a/core/engine/src/loader/mod.rs
+++ b/core/engine/src/loader/mod.rs
@@ -15,7 +15,7 @@ use std::fmt::Debug;
 use std::sync::Arc;
 use thiserror::Error;
 
-pub type LoaderResult<T> = Result<T, LoaderError>;
+pub type LoaderResult<T> = Result<T, Box<LoaderError>>;
 pub type LoaderResponse = LoaderResult<Arc<DecisionContent>>;
 
 /// Trait used for implementing a loader for decisions

--- a/core/engine/src/loader/noop.rs
+++ b/core/engine/src/loader/noop.rs
@@ -12,6 +12,7 @@ impl DecisionLoader for NoopLoader {
         Err(LoaderError::Internal {
             key: key.to_string(),
             source: anyhow!("Loader is no-op"),
-        })
+        }
+        .into())
     }
 }

--- a/test-data/infinite-function.json
+++ b/test-data/infinite-function.json
@@ -1,0 +1,46 @@
+{
+  "edges": [
+    {
+      "id": "7ef2014c-9ea3-4ec2-b3f8-aa3672a0956d",
+      "sourceId": "a2e9b2aa-fbc5-46c1-bbe3-8b4ff45e2f59",
+      "type": "edge",
+      "targetId": "e0fd96d0-44dc-4f0e-b825-06e56b442d78"
+    },
+    {
+      "id": "8b122464-c8eb-4f8a-9deb-7bfd3b94bc96",
+      "sourceId": "e0fd96d0-44dc-4f0e-b825-06e56b442d78",
+      "type": "edge",
+      "targetId": "b8b98fa5-3a16-496d-99bf-7bc6d3caedb3"
+    }
+  ],
+  "nodes": [
+    {
+      "id": "a2e9b2aa-fbc5-46c1-bbe3-8b4ff45e2f59",
+      "type": "inputNode",
+      "position": {
+        "x": 160,
+        "y": 220
+      },
+      "name": "Request"
+    },
+    {
+      "id": "e0fd96d0-44dc-4f0e-b825-06e56b442d78",
+      "type": "functionNode",
+      "position": {
+        "x": 440,
+        "y": 220
+      },
+      "name": "functionNode 1",
+      "content": "/**\n* @param {import('gorules').Input} input\n* @param {{\n*  moment: import('dayjs')\n*  env: Record<string, any>\n* }} helpers\n*/\nconst handler = (input, { moment, env }) => {\n  while (true) {}\n  return input;\n}"
+    },
+    {
+      "id": "b8b98fa5-3a16-496d-99bf-7bc6d3caedb3",
+      "type": "outputNode",
+      "position": {
+        "x": 750,
+        "y": 220
+      },
+      "name": "Response"
+    }
+  ]
+}


### PR DESCRIPTION
Adds more transparency to errors being thrown on the top level. Boxing top-level errors is done to stabilise the API if the error types grow larger than the Ok Result variant and reduce the need for API changes in the future.