### PR TITLE
refactor: remove exec result;

### DIFF
--- a/core/engine/src/handler/table/zen.rs
+++ b/core/engine/src/handler/table/zen.rs
@@ -109,7 +109,7 @@ impl<'a> DecisionTableHandler<'a> {
                 return None;
             }
 
-            let is_ok = result.unwrap().bool().unwrap_or_else(|_| false);
+            let is_ok = result.unwrap().as_bool().unwrap_or(false);
             if !is_ok {
                 return None;
             }
@@ -127,10 +127,7 @@ impl<'a> DecisionTableHandler<'a> {
                 return None;
             }
 
-            outputs.insert(
-                output.field.clone(),
-                RowOutputKind::Value(res.unwrap().to_value().ok()?),
-            );
+            outputs.insert(output.field.clone(), RowOutputKind::Value(res.unwrap()));
         }
 
         if !self.trace {

--- a/core/expression/tests/isolate.rs
+++ b/core/expression/tests/isolate.rs
@@ -1,9 +1,9 @@
 use bumpalo::Bump;
-use rust_decimal_macros::dec;
+
 use serde_json::{json, Value};
 
 use zen_expression::isolate::Isolate;
-use zen_expression::opcodes::{ExecResult, Variable};
+use zen_expression::opcodes::Variable;
 
 struct TestEnv {
     env: Value,
@@ -12,7 +12,7 @@ struct TestEnv {
 
 struct TestCase {
     expr: &'static str,
-    result: ExecResult,
+    result: Value,
 }
 
 #[test]
@@ -25,7 +25,7 @@ fn isolate_standard_test() {
             }),
             cases: Vec::from([TestCase {
                 expr: "hello + world",
-                result: ExecResult::String("Hello, world!".to_string()),
+                result: json!("Hello, world!"),
             }]),
         },
         TestEnv {
@@ -37,19 +37,19 @@ fn isolate_standard_test() {
             cases: Vec::from([
                 TestCase {
                     expr: "a + b - c",
-                    result: ExecResult::Number(dec!(8.0)),
+                    result: json!(8),
                 },
                 TestCase {
                     expr: "b^a",
-                    result: ExecResult::Number(dec!(216.0)),
+                    result: json!(216),
                 },
                 TestCase {
                     expr: "c * b / a",
-                    result: ExecResult::Number(dec!(2.0)),
+                    result: json!(2),
                 },
                 TestCase {
                     expr: "abs(a - b - c)",
-                    result: ExecResult::Number(dec!(4.0)),
+                    result: json!(4),
                 },
             ]),
         },
@@ -64,23 +64,23 @@ fn isolate_standard_test() {
             cases: Vec::from([
                 TestCase {
                     expr: "a == a and a != b",
-                    result: ExecResult::Bool(true),
+                    result: json!(true),
                 },
                 TestCase {
                     expr: "b - a > c",
-                    result: ExecResult::Bool(true),
+                    result: json!(true),
                 },
                 TestCase {
                     expr: "b < a or a > b",
-                    result: ExecResult::Bool(false),
+                    result: json!(false),
                 },
                 TestCase {
                     expr: "t or f",
-                    result: ExecResult::Bool(true),
+                    result: json!(true),
                 },
                 TestCase {
                     expr: "t and f",
-                    result: ExecResult::Bool(false),
+                    result: json!(false),
                 },
             ]),
         },
@@ -89,15 +89,15 @@ fn isolate_standard_test() {
             cases: Vec::from([
                 TestCase {
                     expr: "1 in [1..5] and 5 in [1..5]",
-                    result: ExecResult::Bool(true),
+                    result: json!(true),
                 },
                 TestCase {
                     expr: "1 not in (1..5] and 5 not in [1..5)",
-                    result: ExecResult::Bool(true),
+                    result: json!(true),
                 },
                 TestCase {
                     expr: "1 not in [1.01..5] and 5 not in [1..4.99]",
-                    result: ExecResult::Bool(true),
+                    result: json!(true),
                 },
             ]),
         },
@@ -106,15 +106,15 @@ fn isolate_standard_test() {
             cases: Vec::from([
                 TestCase {
                     expr: r#"date("2022-04-04") > date("2022-03-04")"#,
-                    result: ExecResult::Bool(true),
+                    result: json!(true),
                 },
                 TestCase {
                     expr: r#"duration("60m") == duration("1h")"#,
-                    result: ExecResult::Bool(true),
+                    result: json!(true),
                 },
                 TestCase {
                     expr: r#"duration("24h") >= duration("1d")"#,
-                    result: ExecResult::Bool(true),
+                    result: json!(true),
                 },
             ]),
         },
@@ -123,27 +123,27 @@ fn isolate_standard_test() {
             cases: Vec::from([
                 TestCase {
                     expr: r#"customer.firstName + " " + customer.lastName"#,
-                    result: ExecResult::String("John Doe".to_string()),
+                    result: json!("John Doe"),
                 },
                 TestCase {
                     expr: r#"startsWith(customer.firstName, "Jo")"#,
-                    result: ExecResult::Bool(true),
+                    result: json!(true),
                 },
                 TestCase {
                     expr: r#"endsWith(customer.firstName + customer.lastName, "oe")"#,
-                    result: ExecResult::Bool(true),
+                    result: json!(true),
                 },
                 TestCase {
                     expr: r#"contains(customer.lastName, "Do")"#,
-                    result: ExecResult::Bool(true),
+                    result: json!(true),
                 },
                 TestCase {
                     expr: "upper(customer.firstName) == 'JOHN'",
-                    result: ExecResult::Bool(true),
+                    result: json!(true),
                 },
                 TestCase {
                     expr: "lower(customer.firstName) == 'john'",
-                    result: ExecResult::Bool(true),
+                    result: json!(true),
                 },
             ]),
         },
@@ -157,58 +157,55 @@ fn isolate_standard_test() {
             cases: Vec::from([
                 TestCase {
                     expr: r#"some(customer.groups, # == "admin")"#,
-                    result: ExecResult::Bool(true),
+                    result: json!(true),
                 },
                 TestCase {
                     expr: r#"all(customer.purchaseAmounts, # in [100..800])"#,
-                    result: ExecResult::Bool(true),
+                    result: json!(true),
                 },
                 TestCase {
                     expr: r#"not all(customer.purchaseAmounts, # in (100..800))"#,
-                    result: ExecResult::Bool(true),
+                    result: json!(true),
                 },
                 TestCase {
                     expr: r#"none(customer.purchaseAmounts, # == 99)"#,
-                    result: ExecResult::Bool(true),
+                    result: json!(true),
                 },
                 TestCase {
                     expr: r#"all(customer.groups, # == "admin" or # == "user")"#,
-                    result: ExecResult::Bool(true),
+                    result: json!(true),
                 },
                 TestCase {
                     expr: "count(customer.groups, true)",
-                    result: ExecResult::Number(dec!(2.0)),
+                    result: json!(2),
                 },
                 TestCase {
                     expr: "count(customer.purchaseAmounts, # > 150)",
-                    result: ExecResult::Number(dec!(3.0)),
+                    result: json!(3),
                 },
                 TestCase {
                     expr: "map(customer.purchaseAmounts, # + 50)[0] == 150",
-                    result: ExecResult::Bool(true),
+                    result: json!(true),
                 },
                 TestCase {
                     expr: "filter(customer.purchaseAmounts, # >= 200)[0] == 200",
-                    result: ExecResult::Bool(true),
+                    result: json!(true),
                 },
                 TestCase {
                     expr: "sum(customer.purchaseAmounts[0:1]) == 300",
-                    result: ExecResult::Bool(true),
+                    result: json!(true),
                 },
                 TestCase {
                     expr: "one(customer.groups, # == 'admin')",
-                    result: ExecResult::Bool(true),
+                    result: json!(true),
                 },
                 TestCase {
                     expr: "one(['admin', 'admin'], # == 'admin')",
-                    result: ExecResult::Bool(false),
+                    result: json!(false),
                 },
                 TestCase {
                     expr: r#"map(["admin", "user"], "hello " + #)"#,
-                    result: ExecResult::Array(Vec::from([
-                        ExecResult::String("hello admin".to_string()),
-                        ExecResult::String("hello user".to_string()),
-                    ])),
+                    result: json!(["hello admin", "hello user"]),
                 },
             ]),
         },
@@ -221,31 +218,31 @@ fn isolate_standard_test() {
             cases: Vec::from([
                 TestCase {
                     expr: r#"contains(name, 'ello')"#,
-                    result: ExecResult::Bool(true),
+                    result: json!(true),
                 },
                 TestCase {
                     expr: r#"contains(name, '123')"#,
-                    result: ExecResult::Bool(false),
+                    result: json!(false),
                 },
                 TestCase {
                     expr: r#"contains(groups, 'admin')"#,
-                    result: ExecResult::Bool(true),
+                    result: json!(true),
                 },
                 TestCase {
                     expr: r#"contains(groups, 'hello')"#,
-                    result: ExecResult::Bool(false),
+                    result: json!(false),
                 },
                 TestCase {
                     expr: r#"contains(purchaseAmounts, 100)"#,
-                    result: ExecResult::Bool(true),
+                    result: json!(true),
                 },
                 TestCase {
                     expr: "contains(purchaseAmounts, 150)",
-                    result: ExecResult::Bool(false),
+                    result: json!(false),
                 },
                 TestCase {
                     expr: "len(purchaseAmounts)",
-                    result: ExecResult::Number(dec!(4.0)),
+                    result: json!(4),
                 },
             ]),
         },
@@ -254,31 +251,31 @@ fn isolate_standard_test() {
             cases: Vec::from([
                 TestCase {
                     expr: r#"dayOfWeek(date("2022-11-08"))"#,
-                    result: ExecResult::Number(dec!(2.0)),
+                    result: json!(2),
                 },
                 TestCase {
                     expr: r#"dayOfMonth(date("2022-11-09"))"#,
-                    result: ExecResult::Number(dec!(9.0)),
+                    result: json!(9),
                 },
                 TestCase {
                     expr: r#"dayOfYear(date("2022-11-10"))"#,
-                    result: ExecResult::Number(dec!(314.0)),
+                    result: json!(314),
                 },
                 TestCase {
                     expr: r#"weekOfYear(date("2022-11-12"))"#,
-                    result: ExecResult::Number(dec!(45.0)),
+                    result: json!(45),
                 },
                 TestCase {
                     expr: r#"monthString(date("2022-11-14"))"#,
-                    result: ExecResult::String("Nov".to_string()),
+                    result: json!("Nov"),
                 },
                 TestCase {
                     expr: r#"monthString("2022-11-14")"#,
-                    result: ExecResult::String("Nov".to_string()),
+                    result: json!("Nov"),
                 },
                 TestCase {
                     expr: r#"weekdayString(date("2022-11-14"))"#,
-                    result: ExecResult::String("Mon".to_string()),
+                    result: json!("Mon"),
                 },
             ]),
         },
@@ -287,43 +284,43 @@ fn isolate_standard_test() {
             cases: Vec::from([
                 TestCase {
                     expr: r#"sum([1, 2, 3])"#,
-                    result: ExecResult::Number(dec!(6.0)),
+                    result: json!(6),
                 },
                 TestCase {
                     expr: r#"avg([1, 2, 3])"#,
-                    result: ExecResult::Number(dec!(2.0)),
+                    result: json!(2),
                 },
                 TestCase {
                     expr: r#"min([1, 2, 3])"#,
-                    result: ExecResult::Number(dec!(1.0)),
+                    result: json!(1),
                 },
                 TestCase {
                     expr: r#"max([1, 2, 3])"#,
-                    result: ExecResult::Number(dec!(3.0)),
+                    result: json!(3),
                 },
                 TestCase {
                     expr: r#"floor(3.5)"#,
-                    result: ExecResult::Number(dec!(3.0)),
+                    result: json!(3),
                 },
                 TestCase {
                     expr: r#"ceil(3.5)"#,
-                    result: ExecResult::Number(dec!(4.0)),
+                    result: json!(4),
                 },
                 TestCase {
                     expr: r#"round(4.7)"#,
-                    result: ExecResult::Number(dec!(5.0)),
+                    result: json!(5),
                 },
                 TestCase {
                     expr: r#"rand(10) <= 10"#,
-                    result: ExecResult::Bool(true),
+                    result: json!(true),
                 },
                 TestCase {
                     expr: r#"10 % 4"#,
-                    result: ExecResult::Number(dec!(2.0)),
+                    result: json!(2),
                 },
                 TestCase {
                     expr: r#"true ? 10.0 == 10 : 1.0"#,
-                    result: ExecResult::Bool(true),
+                    result: json!(true),
                 },
             ]),
         },
@@ -332,15 +329,15 @@ fn isolate_standard_test() {
             cases: Vec::from([
                 TestCase {
                     expr: r#"223_000.48 - 120_000_00 / 100"#,
-                    result: ExecResult::Number(dec!(103_000.48)),
+                    result: json!(103_000.48),
                 },
                 TestCase {
                     expr: r#"9223372036854775807"#,
-                    result: ExecResult::Number(dec!(9223372036854775807)),
+                    result: json!(9223372036854775807i64),
                 },
                 TestCase {
                     expr: r#"-9223372036854775807"#,
-                    result: ExecResult::Number(dec!(-9223372036854775807)),
+                    result: json!(-9223372036854775807i64),
                 },
             ]),
         },
@@ -351,19 +348,19 @@ fn isolate_standard_test() {
             cases: Vec::from([
                 TestCase {
                     expr: r#"numbers[0]"#,
-                    result: ExecResult::from(&json!([1, 2, 3])),
+                    result: json!([1, 2, 3]),
                 },
                 TestCase {
                     expr: r#"map(numbers, sum(#))"#,
-                    result: ExecResult::from(&json!([6, 15, 24])),
+                    result: json!([6, 15, 24]),
                 },
                 TestCase {
                     expr: r#"map(numbers, map(#, # - 1))"#,
-                    result: ExecResult::from(&json!([[0, 1, 2], [3, 4, 5], [6, 7, 8]])),
+                    result: json!([[0, 1, 2], [3, 4, 5], [6, 7, 8]]),
                 },
                 TestCase {
                     expr: r#"filter(numbers, some(#, # < 5))"#,
-                    result: ExecResult::from(&json!([[1, 2, 3], [4, 5, 6]])),
+                    result: json!([[1, 2, 3], [4, 5, 6]]),
                 },
             ]),
         },
@@ -374,19 +371,19 @@ fn isolate_standard_test() {
             cases: Vec::from([
                 TestCase {
                     expr: r#"numbers[0]"#,
-                    result: ExecResult::from(&json!([1, 2, 3])),
+                    result: json!([1, 2, 3]),
                 },
                 TestCase {
                     expr: r#"map(numbers, sum(#))"#,
-                    result: ExecResult::from(&json!([6, 15, 24])),
+                    result: json!([6, 15, 24]),
                 },
                 TestCase {
                     expr: r#"map(numbers, map(#, # - 1))"#,
-                    result: ExecResult::from(&json!([[0, 1, 2], [3, 4, 5], [6, 7, 8]])),
+                    result: json!([[0, 1, 2], [3, 4, 5], [6, 7, 8]]),
                 },
                 TestCase {
                     expr: r#"filter(numbers, some(#, # < 5))"#,
-                    result: ExecResult::from(&json!([[1, 2, 3], [4, 5, 6]])),
+                    result: json!([[1, 2, 3], [4, 5, 6]]),
                 },
             ]),
         },
@@ -401,18 +398,14 @@ fn isolate_standard_test() {
             cases: Vec::from([
                 TestCase {
                     expr: r#"filter(cart, some(#.categories, #.categoryId == 'cat1'))"#,
-                    result: ExecResult::from(&json!([
+                    result: json!([
                         { "id": "1", "categories": [{"categoryId": "cat1"}, {"categoryId": "cat2"}] },
                         { "id": "3", "categories": [{"categoryId": "cat1"}, {"categoryId": "cat5"}] }
-                    ])),
+                    ]),
                 },
                 TestCase {
                     expr: r#"map(cart, map(#.categories, #.categoryId))"#,
-                    result: ExecResult::from(&json!([
-                        ["cat1", "cat2"],
-                        ["cat3", "cat4"],
-                        ["cat1", "cat5"],
-                    ])),
+                    result: json!([["cat1", "cat2"], ["cat3", "cat4"], ["cat1", "cat5"],]),
                 },
             ]),
         },
@@ -448,7 +441,7 @@ fn isolate_unary_tests() {
             reference: "customer.groups",
             cases: Vec::from([TestCase {
                 expr: r#"some($, # == "admin")"#,
-                result: ExecResult::Bool(true),
+                result: json!(true),
             }]),
         },
         UnaryTestEnv {
@@ -462,47 +455,47 @@ fn isolate_unary_tests() {
             cases: Vec::from([
                 TestCase {
                     expr: "300",
-                    result: ExecResult::Bool(true),
+                    result: json!(true),
                 },
                 TestCase {
                     expr: ")100..200(",
-                    result: ExecResult::Bool(true),
+                    result: json!(true),
                 },
                 TestCase {
                     expr: "in [100..300]",
-                    result: ExecResult::Bool(true),
+                    result: json!(true),
                 },
                 TestCase {
                     expr: "[100, 200, 300]",
-                    result: ExecResult::Bool(true),
+                    result: json!(true),
                 },
                 TestCase {
                     expr: "100, 200, 300",
-                    result: ExecResult::Bool(true),
+                    result: json!(true),
                 },
                 TestCase {
                     expr: "not in [250, 350]",
-                    result: ExecResult::Bool(true),
+                    result: json!(true),
                 },
                 TestCase {
                     expr: "> 250",
-                    result: ExecResult::Bool(true),
+                    result: json!(true),
                 },
                 TestCase {
                     expr: "< 350",
-                    result: ExecResult::Bool(true),
+                    result: json!(true),
                 },
                 TestCase {
                     expr: "== 300",
-                    result: ExecResult::Bool(true),
+                    result: json!(true),
                 },
                 TestCase {
                     expr: "!= 301",
-                    result: ExecResult::Bool(true),
+                    result: json!(true),
                 },
                 TestCase {
                     expr: ">= 300 and <= 300",
-                    result: ExecResult::Bool(true),
+                    result: json!(true),
                 },
             ]),
         },
@@ -541,7 +534,6 @@ fn variable_serde_test() {
 fn isolate_test_decimals() {
     let isolate = Isolate::default();
     let result = isolate.run_standard("9223372036854775807").unwrap();
-    let value = result.to_value().unwrap();
 
-    assert_eq!(value, Value::from(9223372036854775807i64));
+    assert_eq!(result, Value::from(9223372036854775807i64));
 }


### PR DESCRIPTION
Removes `ExecResult` as it is an unnecessary indirection. Start using serde Value directly instead.