### PR TITLE
fix: unary reference in string;

### DIFF
--- a/core/engine/src/handler/table/zen.rs
+++ b/core/engine/src/handler/table/zen.rs
@@ -104,7 +104,7 @@ impl<'a> DecisionTableHandler<'a> {
                 return None;
             }
 
-            let result = self.isolate.run(rule_value.as_str());
+            let result = self.isolate.run_unary(rule_value.as_str());
             if result.is_err() {
                 return None;
             }

--- a/core/expression/tests/isolate.rs
+++ b/core/expression/tests/isolate.rs
@@ -537,7 +537,7 @@ fn isolate_unary_tests() {
         isolate.set_reference(reference).unwrap();
 
         for TestCase { expr, result } in cases {
-            assert_eq!(result, isolate.run(expr).unwrap(), "{}", expr);
+            assert_eq!(result, isolate.run_unary(expr).unwrap(), "{}", expr);
         }
     }
 }


### PR DESCRIPTION
Fixes a case where the standard parser would kick in if the string contained "$", instead we will be checking for the exact identifier with the exact value after tokenization.