### PR TITLE
improvement: expression error visibility;

### DIFF
--- a/core/engine/src/handler/expression/mod.rs
+++ b/core/engine/src/handler/expression/mod.rs
@@ -63,6 +63,6 @@ impl<'a> ExpressionHandler<'a> {
     fn evaluate_expression(&self, expression: &'a str) -> anyhow::Result<Value> {
         self.isolate
             .run_standard(expression)
-            .context("Failed to evaluate expression")
+            .with_context(|| format!(r#"Failed to evaluate expression: "{expression}""#))
     }
 }


### PR DESCRIPTION
Temporary solution for displaying an error for expression node. There will be a bigger rewrite to how errors are handled in the future.