### PR TITLE
fix: ts evaluate options;

### DIFF
--- a/bindings/nodejs/index.d.ts
+++ b/bindings/nodejs/index.d.ts
@@ -7,17 +7,15 @@ export interface ZenEvaluateOptions {
   maxDepth?: number
   trace?: boolean
 }
-export interface JsZenEngineOptions {
+export interface ZenEngineOptions {
   loader?: (key: string) => Promise<Buffer>
 }
-export type JsZenDecision = ZenDecision
 export class ZenDecision {
   constructor()
-  evaluate(context: any, opts?: JsZenEvaluateOptions | undefined | null): Promise<any>
+  evaluate(context: any, opts?: ZenEvaluateOptions | undefined | null): Promise<any>
 }
-export type JsZenEngine = ZenEngine
 export class ZenEngine {
-  constructor(options?: JsZenEngineOptions | undefined | null)
+  constructor(options?: ZenEngineOptions | undefined | null)
   evaluate(key: string, context: any, opts?: ZenEvaluateOptions | undefined | null): Promise<any>
   createDecision(content: Buffer): ZenDecision
   getDecision(key: string): Promise<ZenDecision>

--- a/bindings/nodejs/src/decision.rs
+++ b/bindings/nodejs/src/decision.rs
@@ -1,4 +1,4 @@
-use crate::engine::JsZenEvaluateOptions;
+use crate::engine::ZenEvaluateOptions;
 use crate::loader::JsDecisionLoader;
 use napi::anyhow::anyhow;
 use napi::tokio;
@@ -7,17 +7,17 @@ use serde_json::Value;
 use std::sync::Arc;
 use zen_engine::{Decision, EvaluationOptions};
 
-#[napi(js_name = "ZenDecision")]
-pub struct JsZenDecision(pub(crate) Arc<Decision<JsDecisionLoader>>);
+#[napi]
+pub struct ZenDecision(pub(crate) Arc<Decision<JsDecisionLoader>>);
 
-impl From<Decision<JsDecisionLoader>> for JsZenDecision {
+impl From<Decision<JsDecisionLoader>> for ZenDecision {
     fn from(value: Decision<JsDecisionLoader>) -> Self {
         Self(value.into())
     }
 }
 
 #[napi]
-impl JsZenDecision {
+impl ZenDecision {
     #[napi(constructor)]
     pub fn new() -> napi::Result<Self> {
         Err(anyhow!("Private constructor").into())
@@ -27,7 +27,7 @@ impl JsZenDecision {
     pub async fn evaluate(
         &self,
         context: Value,
-        opts: Option<JsZenEvaluateOptions>,
+        opts: Option<ZenEvaluateOptions>,
     ) -> napi::Result<Value> {
         let decision = self.0.clone();
         let result = tokio::spawn(async move {

--- a/bindings/nodejs/src/decision.rs
+++ b/bindings/nodejs/src/decision.rs
@@ -1,5 +1,5 @@
 use crate::engine::ZenEvaluateOptions;
-use crate::loader::JsDecisionLoader;
+use crate::loader::DecisionLoader;
 use napi::anyhow::anyhow;
 use napi::tokio;
 use napi_derive::napi;
@@ -8,10 +8,10 @@ use std::sync::Arc;
 use zen_engine::{Decision, EvaluationOptions};
 
 #[napi]
-pub struct ZenDecision(pub(crate) Arc<Decision<JsDecisionLoader>>);
+pub struct ZenDecision(pub(crate) Arc<Decision<DecisionLoader>>);
 
-impl From<Decision<JsDecisionLoader>> for ZenDecision {
-    fn from(value: Decision<JsDecisionLoader>) -> Self {
+impl From<Decision<DecisionLoader>> for ZenDecision {
+    fn from(value: Decision<DecisionLoader>) -> Self {
         Self(value.into())
     }
 }

--- a/bindings/nodejs/src/engine.rs
+++ b/bindings/nodejs/src/engine.rs
@@ -1,5 +1,5 @@
 use crate::decision::ZenDecision;
-use crate::loader::JsDecisionLoader;
+use crate::loader::DecisionLoader;
 use napi::anyhow::{anyhow, Context};
 use napi::bindgen_prelude::Buffer;
 use napi::{tokio, JsFunction};
@@ -11,7 +11,7 @@ use zen_engine::{DecisionEngine, EvaluationOptions};
 
 #[napi]
 pub struct ZenEngine {
-    graph: Arc<DecisionEngine<JsDecisionLoader>>,
+    graph: Arc<DecisionEngine<DecisionLoader>>,
 }
 
 #[napi(object)]
@@ -40,15 +40,15 @@ impl ZenEngine {
     #[napi(constructor)]
     pub fn new(options: Option<ZenEngineOptions>) -> napi::Result<Self> {
         let Some(opts) = options else {
-          return Ok(Self { graph: DecisionEngine::new(JsDecisionLoader::default()).into() })
+          return Ok(Self { graph: DecisionEngine::new(DecisionLoader::default()).into() })
         };
 
         let Some(loader_fn) = opts.loader else {
-            return Ok(Self { graph: DecisionEngine::new(JsDecisionLoader::default()).into() })
+            return Ok(Self { graph: DecisionEngine::new(DecisionLoader::default()).into() })
         };
 
         Ok(Self {
-            graph: DecisionEngine::new(JsDecisionLoader::try_from(loader_fn)?).into(),
+            graph: DecisionEngine::new(DecisionLoader::try_from(loader_fn)?).into(),
         })
     }
 

--- a/bindings/nodejs/src/loader.rs
+++ b/bindings/nodejs/src/loader.rs
@@ -5,20 +5,20 @@ use napi::threadsafe_function::{ErrorStrategy, ThreadSafeCallContext, Threadsafe
 use napi::JsFunction;
 use std::sync::Arc;
 
-use zen_engine::loader::{DecisionLoader, LoaderError, LoaderResult};
+use zen_engine::loader::{DecisionLoader as DecisionLoaderTrait, LoaderError, LoaderResult};
 use zen_engine::model::DecisionContent;
 
-pub(crate) struct JsDecisionLoader {
+pub(crate) struct DecisionLoader {
     function: Option<Arc<ThreadsafeFunction<String, ErrorStrategy::Fatal>>>,
 }
 
-impl Default for JsDecisionLoader {
+impl Default for DecisionLoader {
     fn default() -> Self {
         Self { function: None }
     }
 }
 
-impl TryFrom<JsFunction> for JsDecisionLoader {
+impl TryFrom<JsFunction> for DecisionLoader {
     type Error = napi::Error;
 
     fn try_from(function: JsFunction) -> Result<Self, Self::Error> {
@@ -33,7 +33,7 @@ impl TryFrom<JsFunction> for JsDecisionLoader {
     }
 }
 
-impl JsDecisionLoader {
+impl DecisionLoader {
     pub async fn get_key(&self, key: &str) -> LoaderResult<Arc<DecisionContent>> {
         let Some(function) = &self.function else {
           return Err(LoaderError::Internal {
@@ -71,7 +71,7 @@ impl JsDecisionLoader {
 }
 
 #[async_trait]
-impl DecisionLoader for JsDecisionLoader {
+impl DecisionLoaderTrait for DecisionLoader {
     async fn load(&self, key: &str) -> LoaderResult<Arc<DecisionContent>> {
         let decision_content = self.get_key(key).await?;
         Ok(decision_content)


### PR DESCRIPTION
Fixes an issue with export names from TypeScript likely caused by `js_name` aliasing.