### PR TITLE
fix: remove missing date fns;

### DIFF
--- a/core/expression/src/compiler.rs
+++ b/core/expression/src/compiler.rs
@@ -387,8 +387,8 @@ impl<'a> Compiler<'a> {
                     self.compile_argument(name, arguments, 0)?;
                     Ok(self.emit(Opcode::Random))
                 }
-                "dayOfWeek" | "dayOfMonth" | "dayOfYear" | "weekOfMonth" | "weekOfYear"
-                | "monthOfYear" | "seasonOfYear" | "monthString" | "weekdayString" | "year" => {
+                "dayOfWeek" | "dayOfMonth" | "dayOfYear" | "weekOfYear" | "monthOfYear"
+                | "monthString" | "weekdayString" | "year" => {
                     self.compile_argument(name, arguments, 0)?;
                     Ok(self.emit(Opcode::DateManipulation(name)))
                 }

--- a/core/expression/src/parser/standard/constants.rs
+++ b/core/expression/src/parser/standard/constants.rs
@@ -37,10 +37,8 @@ pub(crate) static BUILT_INS: Lazy<HashMap<&'static str, BuiltIn, ADefHasher>> = 
         "dayOfWeek" => BuiltIn { arity: Arity::Single },
         "dayOfMonth" => BuiltIn { arity: Arity::Single },
         "dayOfYear" => BuiltIn { arity: Arity::Single },
-        "weekOfMonth" => BuiltIn { arity: Arity::Single },
         "weekOfYear" => BuiltIn { arity: Arity::Single },
         "monthOfYear" => BuiltIn { arity: Arity::Single },
-        "seasonOfYear" => BuiltIn { arity: Arity::Single },
         "monthString" => BuiltIn { arity: Arity::Single },
         "weekdayString" => BuiltIn { arity: Arity::Single },
 

--- a/core/expression/src/parser/unary/constants.rs
+++ b/core/expression/src/parser/unary/constants.rs
@@ -30,10 +30,8 @@ pub(crate) const BUILT_INS: Map<&'static str, BuiltIn> = phf_map! {
     "dayOfWeek" => BuiltIn { arity: Arity::Single },
     "dayOfMonth" => BuiltIn { arity: Arity::Single },
     "dayOfYear" => BuiltIn { arity: Arity::Single },
-    "weekOfMonth" => BuiltIn { arity: Arity::Single },
     "weekOfYear" => BuiltIn { arity: Arity::Single },
     "monthOfYear" => BuiltIn { arity: Arity::Single },
-    "seasonOfYear" => BuiltIn { arity: Arity::Single },
     "monthString" => BuiltIn { arity: Arity::Single },
     "weekdayString" => BuiltIn { arity: Arity::Single },
 };

--- a/core/expression/tests/isolate.rs
+++ b/core/expression/tests/isolate.rs
@@ -332,6 +332,10 @@ fn isolate_standard_test() {
                     result: json!("Nov"),
                 },
                 TestCase {
+                    expr: r#"monthOfYear("2022-11-14")"#,
+                    result: json!(11),
+                },
+                TestCase {
                     expr: r#"weekdayString(date("2022-11-14"))"#,
                     result: json!("Mon"),
                 },


### PR DESCRIPTION
Removes unimplemented function from zen expression language.

Affected:
`seasonOfYear` - not useful, and cannot be properly extracted from chrono
`weekOfMonth` - same as above

Added a test for 1 missing function case.