### PR TITLE
fix: node type

### DIFF
--- a/bindings/nodejs/index.d.ts
+++ b/bindings/nodejs/index.d.ts
@@ -13,6 +13,7 @@ export interface ZenEngineOptions {
 export class ZenDecision {
   constructor()
   evaluate(context: any, opts?: ZenEvaluateOptions | undefined | null): Promise<any>
+  validate(): void
 }
 export class ZenEngine {
   constructor(options?: ZenEngineOptions | undefined | null)


### PR DESCRIPTION
regenerates type for `validate` function in typescript