### PR TITLE
fix: go memory leak

### DIFF
--- a/bindings/c/src/custom_node.rs
+++ b/bindings/c/src/custom_node.rs
@@ -1,4 +1,4 @@
-use std::ffi::{c_char, CStr, CString};
+use std::ffi::{c_char, CString};
 
 use anyhow::anyhow;
 
@@ -36,7 +36,7 @@ impl CustomNodeAdapter for DynamicCustomNode {
 
 #[repr(C)]
 pub struct ZenCustomNodeResult {
-    content: *const c_char,
+    content: *mut c_char,
     error: *mut c_char,
 }
 
@@ -56,7 +56,7 @@ impl ZenCustomNodeResult {
             return Err(anyhow!("response not provided"));
         }
 
-        let content_cstr = unsafe { CStr::from_ptr(self.content) };
+        let content_cstr = unsafe { CString::from_raw(self.content) };
         let node_response: NodeResponse = serde_json::from_slice(content_cstr.to_bytes())
             .map_err(|_| anyhow!("failed to deserialize"))?;
 

--- a/bindings/c/src/engine.rs
+++ b/bindings/c/src/engine.rs
@@ -10,6 +10,7 @@ use zen_engine::{DecisionEngine, EvaluationOptions};
 
 use crate::decision::{ZenDecision, ZenDecisionStruct};
 use crate::error::ZenError;
+use crate::helper::safe_str_from_ptr;
 use crate::loader::DynamicDecisionLoader;
 use crate::result::ZenResult;
 
@@ -116,8 +117,7 @@ pub extern "C" fn zen_engine_evaluate(
         return ZenResult::error(ZenError::InvalidArgument);
     }
 
-    let cstr_key = unsafe { CStr::from_ptr(key) };
-    let Ok(str_key) = cstr_key.to_str() else {
+    let Some(str_key) = safe_str_from_ptr(key) else {
         return ZenResult::error(ZenError::InvalidArgument);
     };
 

--- a/bindings/c/src/loader.rs
+++ b/bindings/c/src/loader.rs
@@ -54,7 +54,7 @@ impl ZenDecisionLoaderResult {
         }
 
         let maybe_content = match self.content.is_null() {
-            false => Some(unsafe { CStr::from_ptr(self.content) }),
+            false => Some(unsafe { CString::from_raw(self.content) }),
             true => None,
         };
 

--- a/bindings/c/zen_engine.h
+++ b/bindings/c/zen_engine.h
@@ -54,7 +54,7 @@ typedef struct ZenDecisionLoaderResult {
 typedef struct ZenDecisionLoaderResult (*ZenDecisionLoaderNativeCallback)(const char *key);
 
 typedef struct ZenCustomNodeResult {
-  const char *content;
+  char *content;
   char *error;
 } ZenCustomNodeResult;
 


### PR DESCRIPTION
This leak affects only custom node (in Go) which is currently under development and not part of Go release.