### PR TITLE
feat: add nodejs dispose function

### DIFF
--- a/bindings/nodejs/Cargo.toml
+++ b/bindings/nodejs/Cargo.toml
@@ -10,8 +10,8 @@ crate-type = ["cdylib"]
 
 [dependencies]
 async-trait = { workspace = true }
-napi = { version = "2.16", features = ["serde-json", "error_anyhow", "tokio_rt"] }
-napi-derive = "2.16"
+napi = { version = "2.16.2", features = ["serde-json", "error_anyhow", "tokio_rt"] }
+napi-derive = "2.16.2"
 serde_json = { workspace = true }
 futures = { workspace = true }
 zen-engine = { path = "../../core/engine" }

--- a/bindings/nodejs/README.md
+++ b/bindings/nodejs/README.md
@@ -40,6 +40,7 @@ import fs from 'fs/promises';
 
   const decision = engine.createDecision(content);
   const result = await decision.evaluate({ input: 15 });
+  engine.dispose();
 })();
 ```
 
@@ -58,6 +59,7 @@ const loader = async (key: string) => fs.readFile(path.join(testDataRoot, key))(
     const engine = new ZenEngine({ loader });
 
     const result = await engine.evaluate('jdm_graph1.json', { input: 5 });
+    engine.dispose();
 })();
 ```
 

--- a/bindings/nodejs/index.d.ts
+++ b/bindings/nodejs/index.d.ts
@@ -54,6 +54,11 @@ export class ZenEngine {
   evaluate(key: string, context: any, opts?: ZenEvaluateOptions | undefined | null): Promise<ZenEngineResponse>
   createDecision(content: ZenDecisionContent | Buffer | object): ZenDecision
   getDecision(key: string): Promise<ZenDecision>
+  /**
+   * Function used to dispose memory allocated for loaders
+   * In the future, it will likely be removed and made automatic
+   */
+  dispose(): void
 }
 export class ZenEngineHandlerRequest {
   input: any

--- a/bindings/nodejs/src/custom_node.rs
+++ b/bindings/nodejs/src/custom_node.rs
@@ -1,35 +1,22 @@
 use napi::anyhow::anyhow;
 use napi::bindgen_prelude::Promise;
-use napi::threadsafe_function::{ErrorStrategy, ThreadSafeCallContext, ThreadsafeFunction};
-use napi::{Env, JsFunction};
+use napi::threadsafe_function::{ErrorStrategy, ThreadsafeFunction};
 
 use zen_engine::handler::custom_node_adapter::{CustomNodeAdapter, CustomNodeRequest};
 use zen_engine::handler::node::{NodeResponse, NodeResult};
 
 use crate::types::{ZenEngineHandlerRequest, ZenEngineHandlerResponse};
 
+#[derive(Default)]
 pub(crate) struct CustomNode {
     function: Option<ThreadsafeFunction<ZenEngineHandlerRequest, ErrorStrategy::Fatal>>,
 }
 
-impl Default for CustomNode {
-    fn default() -> Self {
-        Self { function: None }
-    }
-}
-
 impl CustomNode {
-    pub fn try_new(env: &mut Env, function: JsFunction) -> napi::Result<Self> {
-        let mut tsf = function.create_threadsafe_function(
-            0,
-            |cx: ThreadSafeCallContext<ZenEngineHandlerRequest>| Ok(vec![cx.value]),
-        )?;
-
-        tsf.unref(env)?;
-
-        Ok(Self {
+    pub fn new(tsf: ThreadsafeFunction<ZenEngineHandlerRequest, ErrorStrategy::Fatal>) -> Self {
+        Self {
             function: Some(tsf),
-        })
+        }
     }
 }
 

--- a/bindings/nodejs/src/loader.rs
+++ b/bindings/nodejs/src/loader.rs
@@ -3,8 +3,8 @@ use std::sync::Arc;
 use async_trait::async_trait;
 use napi::anyhow::anyhow;
 use napi::bindgen_prelude::{Buffer, Promise};
-use napi::threadsafe_function::{ErrorStrategy, ThreadSafeCallContext, ThreadsafeFunction};
-use napi::{Either, Env, JsFunction};
+use napi::threadsafe_function::{ErrorStrategy, ThreadsafeFunction};
+use napi::Either;
 
 use zen_engine::loader::{DecisionLoader as DecisionLoaderTrait, LoaderError, LoaderResult};
 use zen_engine::model::DecisionContent;
@@ -17,14 +17,7 @@ pub(crate) struct DecisionLoader {
 }
 
 impl DecisionLoader {
-    pub fn try_new(env: &mut Env, function: JsFunction) -> napi::Result<Self> {
-        let mut tsf =
-            function.create_threadsafe_function(0, |cx: ThreadSafeCallContext<String>| {
-                cx.env.create_string(cx.value.as_str()).map(|v| vec![v])
-            })?;
-
-        tsf.unref(env)?;
-
+    pub fn new(tsf: ThreadsafeFunction<String, ErrorStrategy::Fatal>) -> napi::Result<Self> {
         Ok(Self {
             function: Some(tsf),
         })

--- a/bindings/nodejs/test/decision.spec.ts
+++ b/bindings/nodejs/test/decision.spec.ts
@@ -29,6 +29,8 @@ describe('ZenEngine', () => {
     expect(r1.result.output).toEqual(10);
     expect(r2.result.output).toEqual(0);
     expect(r3.result.output).toEqual(10);
+
+    engine.dispose();
   }, 10000);
 
   it('Evaluates decisions using getDecision', async () => {
@@ -46,6 +48,8 @@ describe('ZenEngine', () => {
     expect(r1.result.output).toEqual(20);
     expect(r2.result.output).toEqual(0);
     expect(r3.result.output).toEqual(10);
+
+    engine.dispose();
   }, 10000);
 
   it('Creates a decision from contents', async () => {
@@ -80,6 +84,8 @@ describe('ZenEngine', () => {
 
     const r = await engine.evaluate('custom.json', {a: 5});
     expect(r.result.data).toEqual(25);
+
+    engine.dispose();
   });
 
   it('Parses ZenDecisionContent', async () => {


### PR DESCRIPTION
Adds a new function `dispose` to ZenEngine. This function should be called to ensure proper clean up of memory when creating large numbers of `ZenEngine` instances.

In future, this will be made automatic when NAPI-RS releases new version.