### PR TITLE
add publish details for decision node

### DIFF
--- a/README.md
+++ b/README.md
@@ -315,6 +315,8 @@ decision models during execution.
 By incorporating the "Decision" node, developers can modularize decision logic, promoting reusability and
 maintainability in complex systems.
 
+To use the decision node, you would need to publish the decision model and then refer to that in other decision models. 
+
 ## Support matrix
 
 | Arch            | Rust               | NodeJS             | Python             | Go                 |


### PR DESCRIPTION
To refer decision node, you need to publish the decision node for it to be available and usable in other decision graphs. Refer to https://github.com/gorules/zen/issues/164 for more details