### PR TITLE
feat: add async support to python binding

### DIFF
--- a/bindings/python/Cargo.toml
+++ b/bindings/python/Cargo.toml
@@ -21,3 +21,4 @@ futures = { workspace = true }
 zen-engine = { path = "../../core/engine" }
 zen-expression = { path = "../../core/expression" }
 zen-tmpl = { path = "../../core/template" }
+pyo3-asyncio = { version = "0.20.0", features = ["tokio-runtime"] }

--- a/bindings/python/index.py
+++ b/bindings/python/index.py
@@ -1,5 +1,5 @@
 import zen
-import time
+import asyncio
 import unittest
 
 def loader(key):
@@ -8,6 +8,13 @@ def loader(key):
 
 def custom_handler(request):
     p1 = request.get_field("prop1")
+    return {
+        "output": { "sum": p1 }
+    }
+
+async def custom_async_handler(request):
+    p1 = request.get_field("prop1")
+    await asyncio.sleep(1)
     return {
         "output": { "sum": p1 }
     }
@@ -68,6 +75,40 @@ class ZenEngine(unittest.TestCase):
     def test_render_template(self):
         result = zen.render_template("{{ a + b }}", { "a": 10, "b": 20 })
         self.assertEqual(result, 30)
+
+
+class AsyncZenEngine(unittest.IsolatedAsyncioTestCase):
+    async def test_async_evaluate(self):
+        engine = zen.ZenEngine({"loader": loader})
+        r1 = engine.async_evaluate("function.json", {"input": 5})
+        r2 = engine.async_evaluate("table.json", {"input": 2})
+        r3 = engine.async_evaluate("table.json", {"input": 12})
+
+        results = await asyncio.gather(r1, r2, r3)
+        self.assertEqual(results[0]["result"]["output"], 10)
+        self.assertEqual(results[1]["result"]["output"], 0)
+        self.assertEqual(results[2]["result"]["output"], 10)
+
+    async def test_async_evaluate_custom_handler(self):
+        engine = zen.ZenEngine({"loader": loader, "customHandler": custom_async_handler})
+        r1 = engine.async_evaluate("custom.json", {"a": 10})
+        r2 = engine.async_evaluate("custom.json", {"a": 20})
+        r3 = engine.async_evaluate("custom.json", {"a": 30})
+
+        results = await asyncio.gather(r1, r2, r3)
+        self.assertEqual(results[0]["result"]["sum"], 20)
+        self.assertEqual(results[1]["result"]["sum"], 30)
+        self.assertEqual(results[2]["result"]["sum"], 40)
+
+    async def test_create_decisions_from_content(self):
+        engine = zen.ZenEngine()
+        with open("../../test-data/function.json", "r") as f:
+            functionContent = f.read()
+        functionDecision = engine.create_decision(functionContent)
+
+        r = await functionDecision.async_evaluate({"input": 15})
+        self.assertEqual(r["result"]["output"], 30)
+
 
 # run the test
 unittest.main()

--- a/bindings/python/pyproject.toml
+++ b/bindings/python/pyproject.toml
@@ -32,7 +32,7 @@ keywords = ["gorules",
 ]
 
 [project.optional-dependencies]
-dev = ["black", "bumpver", "isort", "pip-tools", "pytest"]
+dev = ["black", "bumpver", "isort", "pip-tools", "pytest", "asyncio"]
 
 [project.urls]
 Homepage = "https://github.com/gorules/zen"

--- a/bindings/python/src/custom_node.rs
+++ b/bindings/python/src/custom_node.rs
@@ -1,6 +1,7 @@
 use anyhow::anyhow;
 use pyo3::types::PyDict;
-use pyo3::{PyObject, Python};
+use pyo3::{PyObject, PyResult, Python};
+use pyo3_asyncio::tokio::into_future;
 use pythonize::depythonize;
 
 use zen_engine::handler::custom_node_adapter::{CustomNodeAdapter, CustomNodeRequest};
@@ -23,19 +24,37 @@ impl From<Option<PyObject>> for PyCustomNode {
     }
 }
 
+fn extract_custom_node_response(result: PyObject, py: Python<'_>) -> NodeResult {
+    let dict = result.extract::<&PyDict>(py)?;
+    let response: NodeResponse = depythonize(dict)?;
+    Ok(response)
+}
+
 impl CustomNodeAdapter for PyCustomNode {
     async fn handle(&self, request: CustomNodeRequest<'_>) -> NodeResult {
         let Some(callable) = &self.0 else {
             return Err(anyhow!("Custom node handler not provided"));
         };
 
-        let content: NodeResponse = Python::with_gil(|py| {
+        let (future, result) = Python::with_gil(|py| -> PyResult<_> {
             let req = PyNodeRequest::from_request(py, request)?;
             let result = callable.call1(py, (req,))?;
-
-            let dict = result.extract::<&PyDict>(py)?;
-            depythonize(dict)
+            let is_coroutine = result.getattr(py, "__await__").is_ok();
+            if is_coroutine {
+                return Ok((Some(into_future(result.as_ref(py))), None));
+            }
+            Ok((None, Some(extract_custom_node_response(result, py))))
         })?;
+
+        if let Some(result) = result {
+            return result;
+        }
+
+        let result = future.expect("Future or result must be present")?.await?;
+
+        let content = Python::with_gil(|py| -> PyResult<_> {
+            Ok(extract_custom_node_response(result, py))
+        })??;
 
         Ok(content)
     }

--- a/bindings/python/src/custom_node.rs
+++ b/bindings/python/src/custom_node.rs
@@ -50,7 +50,9 @@ impl CustomNodeAdapter for PyCustomNode {
             return result;
         }
 
-        let result = future.expect("Future or result must be present")?.await?;
+        let result = future
+            .ok_or_else(|| anyhow!("Future or result must be present"))??
+            .await?;
 
         let content = Python::with_gil(|py| -> PyResult<_> {
             Ok(extract_custom_node_response(result, py))


### PR DESCRIPTION
I think there is a discrepancy with the NodeJS binding it can evaluate the customer_handler async but the python binding appears not to be able to do this.

I think some async support for the custom node handler in python would be a good add, so for example if you are making an API request in a custom node handler, not blocking the event loop during execution.

However async could be added by the zen team would be appreciated, this PR just to make the ask.