### PR TITLE
feat: customizable fn timeout

### DIFF
--- a/bindings/nodejs/index.d.ts
+++ b/bindings/nodejs/index.d.ts
@@ -5,6 +5,7 @@
 
 export interface ZenConfig {
   nodesInContext?: boolean
+  functionTimeout?: number
 }
 export function overrideConfig(config: ZenConfig): void
 export interface ZenEvaluateOptions {

--- a/bindings/nodejs/src/config.rs
+++ b/bindings/nodejs/src/config.rs
@@ -5,12 +5,19 @@ use zen_engine::ZEN_CONFIG;
 #[napi(object)]
 pub struct ZenConfig {
     pub nodes_in_context: Option<bool>,
+    pub function_timeout: Option<u32>,
 }
 
 #[allow(dead_code)]
 #[napi]
 pub fn override_config(config: ZenConfig) {
     if let Some(val) = config.nodes_in_context {
-        ZEN_CONFIG.nodes_in_context.store(val, Ordering::Relaxed)
+        ZEN_CONFIG.nodes_in_context.store(val, Ordering::Relaxed);
+    }
+
+    if let Some(val) = config.function_timeout {
+        ZEN_CONFIG
+            .function_timeout
+            .store(val as u64, Ordering::Relaxed);
     }
 }

--- a/core/engine/src/config.rs
+++ b/core/engine/src/config.rs
@@ -1,15 +1,19 @@
+use std::sync::atomic::{AtomicBool, AtomicU64};
+
 use once_cell::sync::Lazy;
-use std::sync::atomic::AtomicBool;
 
 #[derive(Debug)]
 pub struct ZenConfig {
     pub nodes_in_context: AtomicBool,
+    /// Function timeout presented in millis
+    pub function_timeout: AtomicU64,
 }
 
 impl Default for ZenConfig {
     fn default() -> Self {
         Self {
             nodes_in_context: AtomicBool::new(true),
+            function_timeout: AtomicU64::new(500),
         }
     }
 }

--- a/core/engine/src/config.rs
+++ b/core/engine/src/config.rs
@@ -13,7 +13,7 @@ impl Default for ZenConfig {
     fn default() -> Self {
         Self {
             nodes_in_context: AtomicBool::new(true),
-            function_timeout: AtomicU64::new(500),
+            function_timeout: AtomicU64::new(5_000),
         }
     }
 }

--- a/core/engine/src/handler/function_v1/mod.rs
+++ b/core/engine/src/handler/function_v1/mod.rs
@@ -1,8 +1,10 @@
+use std::sync::atomic::Ordering;
 use std::time::{Duration, Instant};
 
 use crate::handler::function_v1::script::Script;
 use crate::handler::node::{NodeRequest, NodeResponse, NodeResult};
 use crate::model::{DecisionNodeKind, FunctionNodeContent};
+use crate::ZEN_CONFIG;
 use anyhow::anyhow;
 use rquickjs::Runtime;
 use serde_json::json;
@@ -13,13 +15,18 @@ mod script;
 pub struct FunctionHandler {
     trace: bool,
     runtime: Runtime,
+    max_duration: Duration,
 }
-
-static MAX_DURATION: Duration = Duration::from_millis(500);
 
 impl FunctionHandler {
     pub fn new(trace: bool, runtime: Runtime) -> Self {
-        Self { trace, runtime }
+        let max_duration_millis = ZEN_CONFIG.function_timeout.load(Ordering::Relaxed);
+
+        Self {
+            trace,
+            runtime,
+            max_duration: Duration::from_millis(max_duration_millis),
+        }
     }
 
     pub async fn handle(&self, request: NodeRequest) -> NodeResult {
@@ -32,7 +39,8 @@ impl FunctionHandler {
         }?;
 
         let start = Instant::now();
-        let interrupt_handler = Box::new(move || start.elapsed() > MAX_DURATION);
+        let max_duration = self.max_duration.clone();
+        let interrupt_handler = Box::new(move || start.elapsed() > max_duration);
         self.runtime.set_interrupt_handler(Some(interrupt_handler));
 
         let mut script = Script::new(self.runtime.clone());


### PR DESCRIPTION
# Customizable Function Timeout

This PR introduces configurable timeouts for function execution in both Node.js bindings and the core engine. The default timeout has been increased to 5000ms for better handling of complex operations.

## Features

- 🎛️ Added configurable function timeout
- ⚡ Applied timeout settings to both v1 and modern function handlers

## Technical Changes

- Added `functionTimeout` option to Node.js configuration interface
- Implemented timeout configuration storage using `AtomicU64`
- Updated function handlers to use the configured timeout value
- Applied consistent timeout handling across different function execution contexts

## Example Usage

```typescript
import { overrideConfig } from '@gorules/zen-engine';

// Set custom function timeout (in milliseconds)
overrideConfig({
  functionTimeout: 10000, // 10 seconds
  nodesInContext: true
});
```