### PR TITLE
fix: double borrow

### DIFF
--- a/core/engine/src/handler/traversal.rs
+++ b/core/engine/src/handler/traversal.rs
@@ -76,9 +76,9 @@ impl GraphWalker {
         let node_values = self
             .node_data
             .iter()
-            .map(|(idx, value)| {
-                let weight = g.node_weight(*idx).unwrap();
-                (weight.name.clone(), value.clone())
+            .filter_map(|(idx, value)| {
+                let weight = g.node_weight(*idx)?;
+                Some((weight.name.clone(), value.clone()))
             })
             .collect();
 

--- a/core/expression/src/variable/mod.rs
+++ b/core/expression/src/variable/mod.rs
@@ -235,9 +235,12 @@ fn merge_variables(doc: &mut Variable, patch: &Variable, top_level: bool) {
 
     if doc.is_object() && patch.is_object() {
         let map_ref = doc.as_object().unwrap();
-        let mut map = map_ref.borrow_mut();
-
         let patch_ref = patch.as_object().unwrap();
+        if Rc::ptr_eq(&map_ref, &patch_ref) {
+            return;
+        }
+
+        let mut map = map_ref.borrow_mut();
         let patch = patch_ref.borrow();
         for (key, value) in patch.deref() {
             if value == &Variable::Null {
@@ -249,9 +252,12 @@ fn merge_variables(doc: &mut Variable, patch: &Variable, top_level: bool) {
         }
     } else if doc.is_array() && patch.is_array() {
         let arr_ref = doc.as_array().unwrap();
-        let mut arr = arr_ref.borrow_mut();
-
         let patch_ref = patch.as_array().unwrap();
+        if Rc::ptr_eq(&arr_ref, &patch_ref) {
+            return;
+        }
+
+        let mut arr = arr_ref.borrow_mut();
         let patch = patch_ref.borrow();
         arr.extend(patch.iter().map(|s| s.shallow_clone()));
     } else {


### PR DESCRIPTION
Fixes a case where, during the merge, Rc pointers are equal leading to a double borrow. Also handles an existing unwrap using filter_map for better stability.