### PR TITLE
fix: improve type errors

### DIFF
--- a/core/expression/src/parser/parser.rs
+++ b/core/expression/src/parser/parser.rs
@@ -288,8 +288,11 @@ impl<'arena, 'token_ref, Flavor> Parser<'arena, 'token_ref, Flavor> {
 
         error_literal
             .or(error_mark_end)
-            .or(string_value
-                .map(|t| self.node(Node::String(t.value), |_| NodeMetadata { span: t.span })))
+            .or(string_value.map(|t| {
+                self.node(Node::String(t.value), |_| NodeMetadata {
+                    span: (t.span.0 - 1, t.span.1 + 1),
+                })
+            }))
             .unwrap_or_else(|| {
                 self.error(AstNodeError::Custom {
                     message: afmt!(
@@ -317,7 +320,7 @@ impl<'arena, 'token_ref, Flavor> Parser<'arena, 'token_ref, Flavor> {
             });
         };
 
-        let mut span = (current_token.span.0, 0u32);
+        let mut span = (current_token.span.0 - 1, 0u32);
 
         let mut nodes = BumpVec::new_in(self.bump);
         while TokenKind::QuotationMark(QuotationMark::Backtick) != current_token.kind {

--- a/core/expression/src/variable/types/mod.rs
+++ b/core/expression/src/variable/types/mod.rs
@@ -4,6 +4,7 @@ mod util;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::fmt::Display;
+use std::hash::{Hash, Hasher};
 use std::rc::Rc;
 
 #[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
@@ -35,6 +36,26 @@ impl Display for VariableType {
             VariableType::Constant(c) => write!(f, "{c}"),
             VariableType::Array(v) => write!(f, "{v}[]"),
             VariableType::Object(_) => write!(f, "object"),
+        }
+    }
+}
+
+impl Hash for VariableType {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        match &self {
+            VariableType::Any => 0.hash(state),
+            VariableType::Null => 1.hash(state),
+            VariableType::Bool => 2.hash(state),
+            VariableType::String => 3.hash(state),
+            VariableType::Number => 4.hash(state),
+            VariableType::Constant(c) => c.hash(state),
+            VariableType::Array(arr) => arr.hash(state),
+            VariableType::Object(obj) => {
+                let mut pairs: Vec<_> = obj.iter().collect();
+                pairs.sort_by_key(|i| i.0);
+
+                Hash::hash(&pairs, state);
+            }
         }
     }
 }


### PR DESCRIPTION
Adds few hints to existing intellisense type errors. Also implements `Hash` trait for `VariableType` as it's needed for some operations in WASM context.