### PR TITLE
feat: bump rquickjs, fix loop cache for decisionTable

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,6 +36,3 @@ thiserror = "1.0.63"
 lto = true
 codegen-units = 1
 strip = "symbols"
-
-[patch.crates-io]
-rquickjs-core = { git = "https://github.com/stefan-gorules/rquickjs.git", branch = "master" }

--- a/core/engine/Cargo.toml
+++ b/core/engine/Cargo.toml
@@ -24,7 +24,7 @@ rust_decimal = { workspace = true, features = ["maths-nopanic"] }
 fixedbitset = "0.4.2"
 tokio = { workspace = true, features = ["sync", "time"] }
 reqwest = { version = "0.12", features = ["json", "rustls-tls"], default-features = false }
-rquickjs = { version = "0.7.0", features = ["macro", "loader", "rust-alloc", "futures", "either", "properties"] }
+rquickjs = { version = "0.8.0", features = ["macro", "loader", "rust-alloc", "futures", "either", "properties"] }
 itertools = { workspace = true }
 zen-expression = { path = "../expression", version = "0.33.0" }
 zen-tmpl = { path = "../template", version = "0.33.0" }

--- a/core/engine/Cargo.toml
+++ b/core/engine/Cargo.toml
@@ -24,7 +24,7 @@ rust_decimal = { workspace = true, features = ["maths-nopanic"] }
 fixedbitset = "0.4.2"
 tokio = { workspace = true, features = ["sync", "time"] }
 reqwest = { version = "0.12", features = ["json", "rustls-tls"], default-features = false }
-rquickjs = { version = "0.6.2", features = ["macro", "loader", "rust-alloc", "futures", "either", "properties"] }
+rquickjs = { version = "0.7.0", features = ["macro", "loader", "rust-alloc", "futures", "either", "properties"] }
 itertools = { workspace = true }
 zen-expression = { path = "../expression", version = "0.33.0" }
 zen-tmpl = { path = "../template", version = "0.33.0" }

--- a/core/engine/benches/engine.rs
+++ b/core/engine/benches/engine.rs
@@ -47,7 +47,7 @@ fn bench_functions(c: &mut Criterion) {
     });
 
     c.bench_function("decision/table", |b| {
-        bench_decision(b, "table.json", json!({ "input": 15 }).into());
+        bench_decision(b, "function-v2.json", json!({ "input": 15 }).into());
     });
 }
 

--- a/core/engine/src/handler/function/module/console.rs
+++ b/core/engine/src/handler/function/module/console.rs
@@ -35,7 +35,7 @@ pub struct Log {
     ms_since_run: usize,
 }
 
-#[derive(rquickjs::class::Trace, Clone)]
+#[derive(rquickjs::class::Trace, rquickjs::JsLifetime, Clone)]
 #[rquickjs::class]
 pub struct Console {
     #[qjs(skip_trace)]

--- a/core/engine/src/handler/table/zen.rs
+++ b/core/engine/src/handler/table/zen.rs
@@ -65,6 +65,7 @@ impl<'a> DecisionTableHandlerInner<'a> {
                 async move {
                     let mut self_ref = self_mutex.lock().await;
 
+                    self_ref.isolate.clear_references();
                     self_ref.isolate.set_environment(input);
                     match &content.hit_policy {
                         DecisionTableHitPolicy::First => self_ref.handle_first_hit(&content).await,

--- a/core/expression/src/isolate.rs
+++ b/core/expression/src/isolate.rs
@@ -92,6 +92,10 @@ impl<'a> Isolate<'a> {
         self.references.get(reference).cloned()
     }
 
+    pub fn clear_references(&mut self) {
+        self.references.clear();
+    }
+
     pub fn run_standard(&mut self, source: &'a str) -> Result<Variable, IsolateError> {
         self.bump.with_mut(|b| b.reset());
         let bump = self.bump.get();

--- a/test-data/graphs/table-loop.json
+++ b/test-data/graphs/table-loop.json
@@ -1,0 +1,93 @@
+{
+  "tests": [
+    {
+      "input": {
+        "items": [
+          {
+            "hello": "foo"
+          },
+          {
+            "hello": "koo"
+          }
+        ]
+      },
+      "output": {
+        "res": [
+          {
+            "world": "bar"
+          },
+          {
+            "world": "error"
+          }
+        ]
+      }
+    }
+  ],
+  "nodes": [
+    {
+      "type": "inputNode",
+      "id": "da3ed838-ab74-4f55-a703-2d1b7e507722",
+      "name": "request",
+      "position": {
+        "x": 110,
+        "y": 200
+      }
+    },
+    {
+      "type": "decisionTableNode",
+      "content": {
+        "hitPolicy": "first",
+        "rules": [
+          {
+            "_id": "78f3629d-f7eb-4fdb-94b1-c4be9f7bd534",
+            "6d27354e-56ff-4b25-9160-5fb428c98a5d": "\"foo\"",
+            "4428496f-ee81-4298-a50e-c8093bb619d7": "\"bar\""
+          },
+          {
+            "_id": "582b14c8-df87-4c83-8954-4904dc811a98",
+            "6d27354e-56ff-4b25-9160-5fb428c98a5d": "",
+            "4428496f-ee81-4298-a50e-c8093bb619d7": "\"error\""
+          }
+        ],
+        "inputs": [
+          {
+            "id": "6d27354e-56ff-4b25-9160-5fb428c98a5d",
+            "name": "Input",
+            "field": "hello"
+          }
+        ],
+        "outputs": [
+          {
+            "id": "4428496f-ee81-4298-a50e-c8093bb619d7",
+            "name": "Output",
+            "field": "world"
+          }
+        ],
+        "passThrough": false,
+        "inputField": "items",
+        "outputPath": "res",
+        "executionMode": "loop"
+      },
+      "id": "668e8acb-5b42-4bd6-b399-cbe790df7532",
+      "name": "decisionTable1",
+      "position": {
+        "x": 405,
+        "y": 200
+      }
+    }
+  ],
+  "edges": [
+    {
+      "id": "a1c444c9-d464-4991-a548-452dfcb659d3",
+      "sourceId": "da3ed838-ab74-4f55-a703-2d1b7e507722",
+      "type": "edge",
+      "targetId": "668e8acb-5b42-4bd6-b399-cbe790df7532"
+    }
+  ],
+  "settings": {
+    "validation": {
+      "inputSchema": null,
+      "outputSchema": null
+    }
+  }
+}


### PR DESCRIPTION
This PR addresses two separate issues:

## Decision Table Loop Cache Fix

🐛 Fixed caching issue where isolate environment wasn't properly cleared between loop iterations
🧹 Added clear_references() method to Isolate struct
✅ Added test case verifying loop cache behaviour

The fix ensures proper evaluation of loop-based tables, preventing cached values from affecting subsequent iterations.

## QuickJS Update

⬆️ Updated rquickjs to version 0.8.0
🗑️ Removed custom rquickjs-core patch

These changes were required to address Windows CI pipeline issues and keep our QuickJS implementation up-to-date.