### PR TITLE
feat: add trim function to string data type

### DIFF
--- a/core/expression/src/compiler/compiler.rs
+++ b/core/expression/src/compiler/compiler.rs
@@ -331,6 +331,10 @@ impl<'arena, 'bytecode_ref> CompilerInner<'arena, 'bytecode_ref> {
                     self.emit(Opcode::Rot);
                     Ok(self.emit(Opcode::Pop))
                 }
+                BuiltInFunction::Trim => {
+                    self.compile_argument(kind, arguments, 0)?;
+                    Ok(self.emit(Opcode::Trim))
+                }
                 BuiltInFunction::Date => {
                     self.compile_argument(kind, arguments, 0)?;
                     Ok(self.emit(Opcode::ParseDateTime))

--- a/core/expression/src/compiler/opcode.rs
+++ b/core/expression/src/compiler/opcode.rs
@@ -59,6 +59,7 @@ pub enum Opcode<'a> {
     Join,
     Split,
     Extract,
+    Trim,
     Slice,
     Array,
     Object,

--- a/core/expression/src/intellisense/types/provider.rs
+++ b/core/expression/src/intellisense/types/provider.rs
@@ -456,9 +456,7 @@ impl TypesProvider {
 
                         V(VariableType::Bool)
                     }
-                    BuiltInFunction::Upper
-                    | BuiltInFunction::Lower
-                    | BuiltInFunction::Trim => {
+                    BuiltInFunction::Upper | BuiltInFunction::Lower | BuiltInFunction::Trim => {
                         if !type_list[0].satisfies(&VariableType::String) {
                             self.set_error(arguments[0], format!("Argument of type `{}` is not assignable to parameter of type `string`.", type_list[0]));
                         }

--- a/core/expression/src/intellisense/types/provider.rs
+++ b/core/expression/src/intellisense/types/provider.rs
@@ -456,7 +456,9 @@ impl TypesProvider {
 
                         V(VariableType::Bool)
                     }
-                    BuiltInFunction::Upper | BuiltInFunction::Lower => {
+                    BuiltInFunction::Upper
+                    | BuiltInFunction::Lower
+                    | BuiltInFunction::Trim => {
                         if !type_list[0].satisfies(&VariableType::String) {
                             self.set_error(arguments[0], format!("Argument of type `{}` is not assignable to parameter of type `string`.", type_list[0]));
                         }

--- a/core/expression/src/parser/builtin.rs
+++ b/core/expression/src/parser/builtin.rs
@@ -18,6 +18,7 @@ pub enum BuiltInFunction {
     // String
     Upper,
     Lower,
+    Trim,
     StartsWith,
     EndsWith,
     Matches,
@@ -87,6 +88,7 @@ impl BuiltInFunction {
             // String
             BuiltInFunction::Upper => Arity::Single,
             BuiltInFunction::Lower => Arity::Single,
+            BuiltInFunction::Trim => Arity::Single,
             BuiltInFunction::StartsWith => Arity::Dual,
             BuiltInFunction::EndsWith => Arity::Dual,
             BuiltInFunction::Matches => Arity::Dual,

--- a/core/expression/src/parser/unary.rs
+++ b/core/expression/src/parser/unary.rs
@@ -334,6 +334,7 @@ impl From<&Node<'_>> for UnaryNodeBehaviour {
                 BuiltInFunction::Len => CompareWithReference(Equal),
                 BuiltInFunction::Upper => CompareWithReference(Equal),
                 BuiltInFunction::Lower => CompareWithReference(Equal),
+                BuiltInFunction::Trim => CompareWithReference(Equal),
                 BuiltInFunction::Abs => CompareWithReference(Equal),
                 BuiltInFunction::Sum => CompareWithReference(Equal),
                 BuiltInFunction::Avg => CompareWithReference(Equal),

--- a/core/expression/src/vm/vm.rs
+++ b/core/expression/src/vm/vm.rs
@@ -880,6 +880,21 @@ impl<'arena, 'parent_ref, 'bytecode_ref> VMInner<'arena, 'parent_ref, 'bytecode_
                         }
                     }
                 }
+                Opcode::Trim => {
+                    let a = self.pop()?;
+
+                    match a {
+                        String(a) => {
+                            self.push(String(a.trim().into()));
+                        }
+                        _ => {
+                            return Err(OpcodeErr {
+                                opcode: "Trim".into(),
+                                message: "Unsupported type".into(),
+                            });
+                        }
+                    }
+                }
                 Opcode::Lowercase => {
                     let a = self.pop()?;
 

--- a/core/expression/tests/data/standard.csv
+++ b/core/expression/tests/data/standard.csv
@@ -111,6 +111,9 @@ true ? 10 == 20 : false ? 30 == 40 : true ? 50 == 60 : 70 == 80;;false
 len("Hello, World!");; 13
 lower("Hello, World!");; "hello, world!"
 upper("Hello, World!");; "HELLO, WORLD!"
+trim("HELLO, WORLD!");; "HELLO, WORLD!"
+trim("  HELLO, WORLD!");; "HELLO, WORLD!"
+trim("HELLO, WORLD!  ");; "HELLO, WORLD!"
 startsWith("Hello, World!", "Hello");; true
 startsWith("Hello, World!", "World");; false
 endsWith("Hello, World!", "World!");; true

--- a/core/expression/tests/isolate.rs
+++ b/core/expression/tests/isolate.rs
@@ -243,7 +243,7 @@ fn isolate_standard_test() {
             ]),
         },
         TestEnv {
-            env: json!({ "customer": { "firstName": " John", "middleName": " Dan    ", "lastName": "Doe " } }),
+            env: json!({ "customer": { "firstName": " John", "middleName": " \n Dan    \n", "lastName": "Doe " } }),
             cases: Vec::from([
                 TestCase {
                     expr: r#"trim(customer.firstName) + " " + trim(customer.lastName)"#,

--- a/core/expression/tests/isolate.rs
+++ b/core/expression/tests/isolate.rs
@@ -243,6 +243,27 @@ fn isolate_standard_test() {
             ]),
         },
         TestEnv {
+            env: json!({ "customer": { "firstName": " John", "middleName": " Dan    ", "lastName": "Doe " } }),
+            cases: Vec::from([
+                TestCase {
+                    expr: r#"trim(customer.firstName) + " " + trim(customer.lastName)"#,
+                    result: json!("John Doe"),
+                },
+                TestCase {
+                    expr: "trim(customer.firstName) == 'John'",
+                    result: json!(true),
+                },
+                TestCase {
+                    expr: "trim(customer.middleName) == 'Dan'",
+                    result: json!(true),
+                },
+                TestCase {
+                    expr: "trim(customer.lastName) == 'Doe'",
+                    result: json!(true),
+                },
+            ]),
+        },
+        TestEnv {
             env: json!({
                 "customer": {
                     "groups": ["admin", "user"],


### PR DESCRIPTION
See issue https://github.com/gorules/zen/issues/169.

Add a trim method to the String Zen data type.

Suggested documentation update for: https://docs.gorules.io/docs/string#functions

`trim`

Accepts a string and returns the string with leading and trailing whitespace removed.

```javascript
trim('John Doe'); // "John Doe"
trim(' John Doe '); // "John Doe"
trim('\n John Doe'); // "John Doe"
trim('John Doe'); // "John Doe"
```

(no urgency to merge)