### PR TITLE
WIP: Build C bindings dylib for Ruby (also introducing: Ruby bindings)

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,12 @@ execute [JSON Decision Model (JDM)](https://gorules.io/docs/rules-engine/json-de
 
 An open-source React editor is available on our [JDM Editor](https://github.com/gorules/jdm-editor) repo.
 
+## TMP: building ruby instructions
+
+```
+cargo build --release --no-default-features --target aarch64-apple-darwin
+```
+
 ## Usage
 
 ZEN Engine is built as embeddable BRE for your **Rust**, **NodeJS**, **Python** or **Go** applications.

--- a/bindings/c/Cargo.toml
+++ b/bindings/c/Cargo.toml
@@ -17,7 +17,9 @@ zen-expression = { path = "../../core/expression" }
 zen-tmpl = { path = "../../core/template" }
 
 [lib]
-crate-type = ["staticlib"]
+# crate-type = ["cdylib"]
+crate-type = ["cdylib", "staticlib"]
+# crate-type = ["staticlib"]
 
 [build-dependencies]
 cbindgen = "0.26.0"

--- a/bindings/c/src/languages/go.rs
+++ b/bindings/c/src/languages/go.rs
@@ -89,6 +89,7 @@ pub extern "C" fn zen_engine_new_golang(
 }
 
 #[allow(unused_doc_comments)]
+#[cfg(feature = "go")]
 /// cbindgen:ignore
 extern "C" {
     fn zen_engine_go_loader_callback(cb_ptr: usize, key: *const c_char) -> ZenDecisionLoaderResult;
@@ -96,4 +97,18 @@ extern "C" {
         cb_ptr: usize,
         request: *const c_char,
     ) -> ZenCustomNodeResult;
+}
+
+#[allow(unused_doc_comments)]
+#[cfg(not(feature = "go"))]
+extern "C" {
+    fn zen_engine_go_loader_callback(cb_ptr: usize, key: *const c_char) -> ZenDecisionLoaderResult {
+        unimplemented!()
+    }
+    fn zen_engine_go_custom_node_callback(
+        cb_ptr: usize,
+        request: *const c_char,
+    ) -> ZenCustomNodeResult {
+        unimplemented!()
+    }
 }

--- a/ruby-build.sh
+++ b/ruby-build.sh
@@ -10,7 +10,6 @@ set -e
 for target in "${TARGETS[@]}"; do
     echo "Building for $target..."
     
-    # Different package requirements for different targets
     case $target in
         "x86_64-unknown-linux-gnu")
             PACKAGES="gcc-x86-64-linux-gnu"
@@ -34,5 +33,14 @@ for target in "${TARGETS[@]}"; do
         apt-get update && \
         apt-get install -y $PACKAGES && \
         rustup target add $target && \
-        CC=$CC cargo build --target $target --release --no-default-features"
+        QUICKJS_SYSTEM_MALLOC=1 \
+        QUICKJS_DISABLE_ATOMICS=1 \
+        CC=$CC \
+        RUSTFLAGS='-C target-feature=+crt-static' \
+        cargo clean && \
+        QUICKJS_SYSTEM_MALLOC=1 \
+        QUICKJS_DISABLE_ATOMICS=1 \
+        CC=$CC \
+        RUSTFLAGS='-C target-feature=+crt-static' \
+        cargo build --target $target --release --no-default-features"
 done

--- a/ruby-build.sh
+++ b/ruby-build.sh
@@ -32,7 +32,7 @@ for target in "${TARGETS[@]}"; do
     docker run --rm --platform $DOCKER_PLATFORM \
         -v "$(pwd)":/workspace \
         -w /workspace/bindings/c \
-        rust:1.70 bash -c "\
+        rust:1.73 bash -c "\
         apt-get update && \
         apt-get install -y $PACKAGES && \
         rustup target add $target && \

--- a/ruby-build.sh
+++ b/ruby-build.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+TARGETS=(
+    "x86_64-unknown-linux-gnu"
+    "aarch64-unknown-linux-gnu"
+    "x86_64-unknown-linux-musl"
+)
+
+set -e
+
+for target in "${TARGETS[@]}"; do
+    echo "Building for $target..."
+    
+    # Different package requirements for different targets
+    case $target in
+        "x86_64-unknown-linux-gnu")
+            PACKAGES="gcc-x86-64-linux-gnu"
+            CC="x86_64-linux-gnu-gcc"
+            ;;
+        "aarch64-unknown-linux-gnu")
+            PACKAGES="gcc-aarch64-linux-gnu"
+            CC="aarch64-linux-gnu-gcc"
+            ;;
+        "x86_64-unknown-linux-musl")
+            PACKAGES="musl-tools"
+            CC="musl-gcc"
+            ;;
+        *)
+            echo "Unknown target: $target"
+            exit 1
+            ;;
+    esac
+
+    docker run --rm -v "$(pwd)":/workspace -w /workspace/bindings/c rust:latest bash -c "\
+        apt-get update && \
+        apt-get install -y $PACKAGES && \
+        rustup target add $target && \
+        CC=$CC cargo build --target $target --release --no-default-features"
+done


### PR DESCRIPTION
Hello! I have what I hope will be considered cool news:

## Ruby Bindings for ZEN Engine

https://github.com/FutureProofRetail/zen-engine-ruby

I had a use case for evaluating rules in a Ruby context and saw [there is no plans to build or support Ruby bindings](https://github.com/gorules/zen/issues/173), so I started in on my own implementation here: https://github.com/FutureProofRetail/zen-engine-ruby

It is still very Alpha (literally crashes half the time due to a double-free pointer error which I believe is easy to fix, just need to fix something in our use of Ruby FFI gem). Here are the remaining issues I'm aware of: https://github.com/FutureProofRetail/zen-engine-ruby

## Is it ok to host under our repo/org?

I decided to implement the Ruby bindings in its own repo because:

- I wasn't sure GoRules team would be interested in helping support it, therefore I figured it might not make sense to be in this main repo
- The Golang bindings live in a separate repo, which served as a decent example for us

That said, even the Golang repo is hosted under the gorules GitHub org; I don't mind transferring our work to the gorules org if there is a strong desire for it, but if it's unlikely that Ruby bindings will get much support from the gorules team (which seems likely) then maybe it makes sense to continue to host on ours.

## Implementation Approach for Ruby Bindings (help needed)

Ruby is an interpreted language and the easiest way to implement FFI with Rust-like languages is to use the [FFI Ruby gem](https://github.com/ffi/ffi) which lets you define an interface to shared libraries (.so, .dylib) via a Ruby interface, without requiring users to compile native extensions when installing your gem.

Therefore, I need a cdylib version of the C bindings within this repo. I don't have a lot of familiarity with this realm so when I added `cdylib` to the `crate-type` array I started getting build errors due to unimplement Go-lang fns. I added a few feature flags and then got things building on my mac, which allowed me to proceed with getting the Ruby bindings to pass tests.

Obviously, we'll need to clean this up, but I could use some guidance:

1. Is it the right way to go to change `crate-type` to `crate-type = ["cdylib", "staticlib"]` ?
2. Any idea the right way to fix the golang errors?
3. I see a few features including "bincode"... is that expected to be enabled when compiling? Are there other important features to keep in mind?
4. Going forward, what is the best way to periodically build the cdylibs for the Ruby bindings? I'm not sure how the Golang repo does it; do they periodically swap out the dylibs based on some CI build? Or running some local docker script?






