### PR TITLE
fix: unary closure expression

### DIFF
--- a/core/expression/src/parser/standard.rs
+++ b/core/expression/src/parser/standard.rs
@@ -63,7 +63,7 @@ impl<'arena, 'token_ref> Parser<'arena, 'token_ref, Standard> {
 
         if precedence == 0 {
             if let Some(conditional_node) =
-                self.conditional(node_left, || self.binary_expression(0))
+                self.conditional(node_left, |_| self.binary_expression(0))
             {
                 node_left = conditional_node;
             }
@@ -84,7 +84,7 @@ impl<'arena, 'token_ref> Parser<'arena, 'token_ref, Standard> {
             self.next();
 
             let node = self.node(Node::Pointer, |_| NodeMetadata { span: token.span });
-            return self.with_postfix(node, || self.binary_expression(0));
+            return self.with_postfix(node, |_| self.binary_expression(0));
         }
 
         if let TokenKind::Operator(operator) = &token.kind {
@@ -114,7 +114,7 @@ impl<'arena, 'token_ref> Parser<'arena, 'token_ref, Standard> {
             return node;
         }
 
-        if let Some(interval_node) = self.interval(|| self.binary_expression(0)) {
+        if let Some(interval_node) = self.interval(|_| self.binary_expression(0)) {
             return interval_node;
         }
 
@@ -131,9 +131,9 @@ impl<'arena, 'token_ref> Parser<'arena, 'token_ref, Standard> {
                 span: (p_start.unwrap_or_default(), self.prev_token_end()),
             });
 
-            return self.with_postfix(expr, || self.binary_expression(0));
+            return self.with_postfix(expr, |_| self.binary_expression(0));
         }
 
-        self.literal(|| self.binary_expression(0))
+        self.literal(|_| self.binary_expression(0))
     }
 }

--- a/core/expression/tests/data/unary.csv
+++ b/core/expression/tests/data/unary.csv
@@ -64,6 +64,7 @@ rand(100) >= 0 and rand(100) <= 100; { "$": true }; true
 sum([1, 2, 3, 4, 5]) / len([1, 2, 3, 4, 5]); { "$": 3 }; true
 median([4, 2, 7, 5, 3]); { "$": 4 }; true
 mode([1, 2, 2, 3, 3, 3, 4, 4, 4, 4]); { "$": 4 }; true
+some($, # > 10 and # < 20); { "$": [1, 2, 3, 15] }; true
 
 # String expressions
 'GB','US';{$: 'US'};true


### PR DESCRIPTION
This PR fixes a bug where multiple conditions using logical operators (`and`, `or`) were not working correctly within closure expressions when using the Unary parser mode. The fix specifically addresses cases like `some($, # > 10 and # < 20)` where the Unary parser was prematurely breaking on logical operators.

## Changes
- 🐛 Fixed handling of logical operators (`and`, `or`) in Unary parser's closure expressions
- ✨ Added context awareness to prevent premature breaks on logical operators in closure contexts
- 🔧 Modified Unary parser's binary expression evaluation to respect closure context

## Example
Previously failing expressions that now work in Unary mode:

```js
some($, # > 10 and # < 20)    // Previously broke on 'and'
```

## Technical Details

- Added `ParserContext` to differentiate between global and closure contexts in Unary parser
- Modified binary expression parsing to only break on logical operators in global context
- Added test case to verify multiple conditions in closure expressions