### PR TITLE
feat: pyexpr remove evaluate many

### DIFF
--- a/bindings/python/src/expression.rs
+++ b/bindings/python/src/expression.rs
@@ -1,14 +1,10 @@
 use crate::variable::PyVariable;
 use anyhow::{anyhow, Context};
 use either::Either;
-use pyo3::types::{PyDict, PyList};
-use pyo3::{
-    pyclass, pyfunction, pymethods, Bound, IntoPyObject, IntoPyObjectExt, Py, PyAny, PyErr,
-    PyResult, Python,
-};
+use pyo3::types::PyDict;
+use pyo3::{pyclass, pyfunction, pymethods, Bound, IntoPyObjectExt, Py, PyAny, PyResult, Python};
 use pythonize::depythonize;
 use zen_expression::expression::{Standard, Unary};
-use zen_expression::vm::VM;
 use zen_expression::{Expression, Variable};
 
 #[pyfunction]
@@ -99,42 +95,5 @@ impl PyExpression {
             .map_err(|e| anyhow!(serde_json::to_string(&e).unwrap_or_else(|_| e.to_string())))?;
 
         PyVariable(result).into_py_any(py)
-    }
-
-    pub fn evaluate_many(&self, py: Python, ctx: &Bound<'_, PyList>) -> PyResult<Py<PyAny>> {
-        let contexts: Vec<Variable> = depythonize(ctx).context("Failed to convert contexts")?;
-
-        let mut vm = VM::new();
-        let results: Vec<_> = contexts
-            .into_iter()
-            .map(|context| {
-                let result = match &self.expression {
-                    Either::Left(standard) => standard.evaluate_with(context, &mut vm),
-                    Either::Right(unary) => {
-                        unary.evaluate_with(context, &mut vm).map(Variable::Bool)
-                    }
-                };
-
-                match result {
-                    Ok(ok) => Either::Left(PyVariable(ok)),
-                    Err(err) => Either::Right(PyExpressionError(err.to_string())),
-                }
-            })
-            .collect();
-
-        results.into_py_any(py)
-    }
-}
-
-struct PyExpressionError(String);
-
-impl<'py> IntoPyObject<'py> for PyExpressionError {
-    type Target = PyAny;
-    type Output = Bound<'py, PyAny>;
-    type Error = PyErr;
-
-    fn into_pyobject(self, py: Python<'py>) -> Result<Self::Output, Self::Error> {
-        let err = pyo3::exceptions::PyException::new_err(self.0);
-        err.into_bound_py_any(py)
     }
 }

--- a/bindings/python/zen.pyi
+++ b/bindings/python/zen.pyi
@@ -42,14 +42,5 @@ def compile_expression(expression: str) -> Expression: ...
 
 def compile_unary_expression(expression: str) -> Expression: ...
 
-
-class ExpressionResult(TypedDict):
-    success: bool
-    result: Optional[Any]
-    error: Optional[str]
-
-
 class Expression:
     def evaluate(self, ctx: Optional[dict] = None) -> Any: ...
-
-    def evaluate_many(self, ctxs: list[dict]) -> list[ExpressionResult]: ...


### PR DESCRIPTION
# Remove Batch Expression Evaluation

This PR removes the `evaluate_many` functionality from Python bindings after performance analysis showed minimal benefits compared to sequential evaluation.

## Changes

- 🔥 Removed `evaluate_many` method from `Expression` class
- 🧹 Cleaned up associated types and error handling code
- 📝 Updated Python type definitions to reflect the changes

## Migration
Not needed, as the Python version with compiled expressions hasn't been released yet.