### PR TITLE
fix: py validate methods

### DIFF
--- a/bindings/python/Cargo.toml
+++ b/bindings/python/Cargo.toml
@@ -11,7 +11,6 @@ crate-type = ["cdylib"]
 
 [dependencies]
 anyhow = { workspace = true }
-bumpalo = "3"
 either = "1.13"
 pyo3 = { version = "0.23", features = ["anyhow", "serde", "either"] }
 pyo3-async-runtimes = { version = "0.23", features = ["tokio-runtime", "attributes"] }

--- a/bindings/python/src/lib.rs
+++ b/bindings/python/src/lib.rs
@@ -2,7 +2,7 @@ use crate::decision::PyZenDecision;
 use crate::engine::PyZenEngine;
 use crate::expression::{
     compile_expression, compile_unary_expression, evaluate_expression, evaluate_unary_expression,
-    py_validate_expression, py_validate_unary_expression, render_template, PyExpression,
+    render_template, validate_expression, validate_unary_expression, PyExpression,
 };
 use pyo3::prelude::PyModuleMethods;
 use pyo3::types::PyModule;
@@ -28,8 +28,8 @@ fn zen(_py: Python, m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(render_template, m)?)?;
     m.add_function(wrap_pyfunction!(compile_expression, m)?)?;
     m.add_function(wrap_pyfunction!(compile_unary_expression, m)?)?;
-    m.add_function(wrap_pyfunction!(py_validate_expression, m)?)?;
-    m.add_function(wrap_pyfunction!(py_validate_unary_expression, m)?)?;
+    m.add_function(wrap_pyfunction!(validate_expression, m)?)?;
+    m.add_function(wrap_pyfunction!(validate_unary_expression, m)?)?;
 
     Ok(())
 }

--- a/bindings/python/zen.pyi
+++ b/bindings/python/zen.pyi
@@ -54,6 +54,5 @@ def validate_unary_expression(expression: str) -> Optional[ValidationResponse]: 
 
 
 class ValidationResponse(TypedDict):
-    type: Literal["lexerError","parserError", "compilerError"]
+    type: Literal["lexerError", "parserError", "compilerError"]
     source: str
-

--- a/core/expression/src/validate.rs
+++ b/core/expression/src/validate.rs
@@ -1,98 +1,15 @@
-use bumpalo::Bump;
+use crate::{Isolate, IsolateError};
 
-use crate::{compiler::Compiler, lexer::Lexer, parser::Parser};
+pub fn validate_unary_expression(expression: &str) -> Result<(), IsolateError> {
+    let mut isolate = Isolate::new();
+    isolate.compile_unary(expression)?;
 
-pub struct ValidationError {
-    pub error_type: String,
-    pub source: String,
+    Ok(())
 }
 
-pub fn validate_unary_expression(expression: &str) -> Option<ValidationError> {
-    let mut lexer = Lexer::new();
-    let tokens = match lexer.tokenize(expression) {
-        Err(e) => {
-            return Some(ValidationError {
-                error_type: "lexerError".to_string(),
-                source: e.to_string(),
-            })
-        }
-        Ok(tokens) => tokens,
-    };
+pub fn validate_expression(expression: &str) -> Result<(), IsolateError> {
+    let mut isolate = Isolate::new();
+    isolate.compile_standard(expression)?;
 
-    let bump = Bump::new();
-    let parser = match Parser::try_new(tokens, &bump) {
-        Err(e) => {
-            return Some(ValidationError {
-                error_type: "parserError".to_string(),
-                source: e.to_string(),
-            })
-        }
-        Ok(p) => p.unary(),
-    };
-
-    let parser_result = parser.parse();
-    match parser_result.error() {
-        Err(e) => {
-            return Some(ValidationError {
-                error_type: "parserError".to_string(),
-                source: e.to_string(),
-            })
-        }
-        Ok(n) => n,
-    };
-
-    let mut compiler = Compiler::new();
-    if let Err(e) = compiler.compile(parser_result.root) {
-        return Some(ValidationError {
-            error_type: "compilerError".to_string(),
-            source: e.to_string(),
-        });
-    }
-
-    None
-}
-
-pub fn validate_expression(expression: &str) -> Option<ValidationError> {
-    let mut lexer = Lexer::new();
-    let tokens = match lexer.tokenize(expression) {
-        Err(e) => {
-            return Some(ValidationError {
-                error_type: "lexerError".to_string(),
-                source: e.to_string(),
-            })
-        }
-        Ok(tokens) => tokens,
-    };
-
-    let bump = Bump::new();
-    let parser = match Parser::try_new(tokens, &bump) {
-        Err(e) => {
-            return Some(ValidationError {
-                error_type: "parserError".to_string(),
-                source: e.to_string(),
-            })
-        }
-        Ok(p) => p.standard(),
-    };
-
-    let parser_result = parser.parse();
-    match parser_result.error() {
-        Err(e) => {
-            return Some(ValidationError {
-                error_type: "parserError".to_string(),
-                source: e.to_string(),
-            })
-        }
-        Ok(n) => n,
-    };
-
-    let mut compiler = Compiler::new();
-    if let Err(e) = compiler.compile(parser_result.root) {
-        return Some(ValidationError {
-            error_type: "compilerError".to_string(),
-            source: e.to_string(),
-        });
-    }
-
-    None
+    Ok(())
 }


### PR DESCRIPTION
# Simplified Expression Validation for Python Bindings

This PR refactors the expression validation system in Python bindings to reduce code complexity while maintaining full validation capabilities.