### PR TITLE
Division by zero does not panic

### DIFF
--- a/core/expression/src/vm/error.rs
+++ b/core/expression/src/vm/error.rs
@@ -16,6 +16,9 @@ pub enum VMError {
 
     #[error("Number conversion error")]
     NumberConversionError,
+
+    #[error("Undefined numerical operation")]
+    OpcodeUndefinedNumericalOperation { opcode: String, message: String },
 }
 
 pub(crate) type VMResult<T> = Result<T, VMError>;

--- a/core/expression/src/vm/vm.rs
+++ b/core/expression/src/vm/vm.rs
@@ -833,6 +833,12 @@ impl<'arena, 'parent_ref, 'bytecode_ref> VMInner<'parent_ref, 'bytecode_ref> {
                     let a = self.pop()?;
 
                     match (a, b) {
+                        (_, Number(a)) if a == Decimal::ZERO => {
+                            return Err(OpcodeUndefinedNumericalOperation {
+                                opcode: "Divide".into(),
+                                message: "Division by zero".into(),
+                            });
+                        }
                         (Number(a), Number(b)) => self.push(Number(a / b)),
                         _ => {
                             return Err(OpcodeErr {

--- a/core/expression/src/vm/vm.rs
+++ b/core/expression/src/vm/vm.rs
@@ -833,17 +833,10 @@ impl<'arena, 'parent_ref, 'bytecode_ref> VMInner<'parent_ref, 'bytecode_ref> {
                     let a = self.pop()?;
 
                     match (a, b) {
-                        (Number(a), Number(b)) => {
-                            match a.checked_div(b) {
-                                Some(result) => self.push(Number(result)),
-                                None => {
-                                    return Err(OpcodeUndefinedNumericalOperation {
-                                        opcode: "Divide".into(),
-                                        message: "Undefined division operation".into(),
-                                    });
-                                }
-                            }
-                        },
+                        (Number(a), Number(b)) => self.push(match a.checked_div(b) {
+                            None => Null,
+                            Some(i) => Number(i)
+                        }),
                         _ => {
                             return Err(OpcodeErr {
                                 opcode: "Divide".into(),

--- a/core/expression/src/vm/vm.rs
+++ b/core/expression/src/vm/vm.rs
@@ -833,13 +833,17 @@ impl<'arena, 'parent_ref, 'bytecode_ref> VMInner<'parent_ref, 'bytecode_ref> {
                     let a = self.pop()?;
 
                     match (a, b) {
-                        (_, Number(a)) if a == Decimal::ZERO => {
-                            return Err(OpcodeUndefinedNumericalOperation {
-                                opcode: "Divide".into(),
-                                message: "Division by zero".into(),
-                            });
-                        }
-                        (Number(a), Number(b)) => self.push(Number(a / b)),
+                        (Number(a), Number(b)) => {
+                            match a.checked_div(b) {
+                                Some(result) => self.push(Number(result)),
+                                None => {
+                                    return Err(OpcodeUndefinedNumericalOperation {
+                                        opcode: "Divide".into(),
+                                        message: "Undefined division operation".into(),
+                                    });
+                                }
+                            }
+                        },
                         _ => {
                             return Err(OpcodeErr {
                                 opcode: "Divide".into(),

--- a/core/expression/tests/isolate.rs
+++ b/core/expression/tests/isolate.rs
@@ -62,6 +62,22 @@ fn isolate_standard_test() {
         },
         TestEnv {
             env: json!({
+                "a": 1,
+                "b": 0
+            }),
+            cases: Vec::from([
+                TestCase {
+                    expr: "a / b",
+                    result: json!(null),
+                },
+                TestCase {
+                    expr: "b / a",
+                    result: json!(0),
+                }
+            ])
+        },
+        TestEnv {
+            env: json!({
                 "a": 3.14f64,
                 "b": 2,
                 "c": 3.141592653589793f64,

--- a/core/expression/tests/isolate.rs
+++ b/core/expression/tests/isolate.rs
@@ -763,6 +763,17 @@ fn isolate_test_decimals() {
 }
 
 #[test]
+fn test_divide_by_zero() {
+    let mut isolate = Isolate::new();
+    let result_err = isolate.run_unary("1 / 0").unwrap_err();
+    assert_eq!(
+        result_err.to_string(),
+        "VM error: Undefined numerical operation",
+        "Expression error: {result_err:?}"
+    );
+}
+
+#[test]
 fn test_standard_csv() {
     let csv_data = include_str!("data/standard.csv");
     let mut r = csv::ReaderBuilder::new()


### PR DESCRIPTION
Dividing by zero raises a panic, irrecoverably preventing further evaluations. Given the sensitive use-cases for this engine, ideally panics should be replaced with a null value instead. 