### PR TITLE
feat: interval iterator

### DIFF
--- a/core/expression/src/vm/error.rs
+++ b/core/expression/src/vm/error.rs
@@ -2,7 +2,7 @@ use thiserror::Error;
 
 #[derive(Debug, PartialEq, Eq, Clone, Error)]
 pub enum VMError {
-    #[error("Unsupported opcode type")]
+    #[error("Unsupported opcode type in '{opcode}'")]
     OpcodeErr { opcode: String, message: String },
 
     #[error("Opcode out of bounds")]

--- a/core/expression/src/vm/variable.rs
+++ b/core/expression/src/vm/variable.rs
@@ -55,4 +55,24 @@ impl IntervalObject {
             left,
         })
     }
+
+    pub(crate) fn to_array(&self) -> Option<Vec<Variable>> {
+        let start = match &self.left_bracket {
+            Bracket::LeftParenthesis => self.left.as_number()?.to_usize()? + 1,
+            Bracket::LeftSquareBracket => self.left.as_number()?.to_usize()?,
+            _ => return None,
+        };
+
+        let end = match &self.right_bracket {
+            Bracket::RightParenthesis => self.right.as_number()?.to_usize()? - 1,
+            Bracket::RightSquareBracket => self.right.as_number()?.to_usize()?,
+            _ => return None,
+        };
+
+        let list = (start..=end)
+            .map(|n| Variable::Number(Decimal::from(n)))
+            .collect::<Vec<_>>();
+
+        Some(list)
+    }
 }

--- a/core/expression/tests/data/standard.csv
+++ b/core/expression/tests/data/standard.csv
@@ -276,6 +276,12 @@ values(customer);{"customer": {"firstName": "John"}};["John"]
 values(customer);{"customer": {"lastName": "Doe"}};["Doe"]
 {};;{}
 
+# Interval iterator
+map([0..3], #);[0, 1, 2, 3]
+map((0..3], #);[1, 2, 3]
+map([0..3), #);[0, 1, 2]
+map((0..3), #);[1, 2]
+
 # Nullish coalescing
 null ?? 'hello';;'hello'
 null ?? 123 ?? 321;;123


### PR DESCRIPTION
# Interval Iterator Implementation

This PR adds support for interval notation as iterable objects in expressions, allowing iteration over numeric ranges with inclusive or exclusive boundaries.

## Technical Changes

- Updated the VM's `Begin` opcode handler to support interval objects
- Improved error messages in the VM for better debugging
- Added comprehensive tests for all interval notation combinations:
  - `[0..3]` (inclusive-inclusive)
  - `(0..3]` (exclusive-inclusive)
  - `[0..3)` (inclusive-exclusive)
  - `(0..3)` (exclusive-exclusive)

## Example Usage

```
map([0..3], #)    // Returns [0, 1, 2, 3]
map((0..3], #)    // Returns [1, 2, 3]
map([0..3), #)    // Returns [0, 1, 2]
map((0..3), #)    // Returns [1, 2]
```

This enhancement provides a more concise and expressive way to iterate over numeric ranges in expressions, similar to range syntax found in many programming languages.