### PR TITLE
fix: http js module breaking on config provided without data (POST)

### DIFF
--- a/core/engine/src/handler/function/module/http.rs
+++ b/core/engine/src/handler/function/module/http.rs
@@ -35,7 +35,6 @@ async fn execute_http<'js>(
     config: Option<HttpConfig>,
 ) -> rquickjs::Result<HttpResponse<'js>> {
     static HTTP_CLIENT: OnceLock<reqwest::Client> = OnceLock::new();
-
     let client = HTTP_CLIENT.get_or_init(|| reqwest::Client::new()).clone();
     let mut builder = client.request(method, url);
     if let Some(data) = data {
@@ -48,7 +47,9 @@ async fn execute_http<'js>(
             .query(config.params.as_slice());
 
         if let Some(data) = config.data {
-            builder = builder.json(&data.0);
+            if !matches!(data.0, Variable::Null) {
+                builder = builder.json(&data.0);
+            }
         }
     }
 


### PR DESCRIPTION
Providing third(config) parameter in the http call, that doesn't have data value defined would override the seconf parameter (body) with null value. Check is now in place that if no data is defined in config, body parameter is used.