### PR TITLE
chore: improve release process

### DIFF
--- a/.github/workflows/miri.yaml
+++ b/.github/workflows/miri.yaml
@@ -22,7 +22,7 @@ jobs:
         with:
           shared-key: rust-miri
           sccache: 'false'
-      - run: cargo miri test --workspace --all-features
+      - run: cargo miri test --workspace --all-features --locked
         env:
           MIRIFLAGS: -Zmiri-strict-provenance -Zmiri-symbolic-alignment-check -Zmiri-disable-isolation
           RUSTFLAGS: ${{ env.RUSTFLAGS }} -Z randomize-layout

--- a/.github/workflows/node.yaml
+++ b/.github/workflows/node.yaml
@@ -43,13 +43,13 @@ jobs:
           - host: windows-latest
             target: 'x86_64-pc-windows-msvc'
             build: |
-              yarn build --target x86_64-pc-windows-msvc
+              yarn build --target x86_64-pc-windows-msvc -- --locked
 
           - host: macos-15-intel
             target: 'x86_64-apple-darwin'
             build: |
               rustup target add x86_64-apple-darwin
-              yarn build --target x86_64-apple-darwin
+              yarn build --target x86_64-apple-darwin -- --locked
               strip -x ./*.node
 
           - host: macos-latest
@@ -60,7 +60,7 @@ jobs:
               export CXX=$(xcrun -f clang++);
               SYSROOT=$(xcrun --sdk macosx --show-sdk-path);
               export CFLAGS="-isysroot $SYSROOT -isystem $SYSROOT";
-              yarn build --target aarch64-apple-darwin
+              yarn build --target aarch64-apple-darwin -- --locked
               strip -x ./*.node
 
           - host: ubuntu-latest
@@ -71,7 +71,7 @@ jobs:
               rustup target add x86_64-unknown-linux-gnu
               mkdir -p ../../target
               ln -sfn x86_64-unknown-linux-gnu ../../target/x86_64-unknown-linux-gnu.$GLIBC_VERSION
-              yarn build --target x86_64-unknown-linux-gnu.$GLIBC_VERSION --cross-compile
+              yarn build --target x86_64-unknown-linux-gnu.$GLIBC_VERSION --cross-compile -- --locked
               mv -f zen-engine.linux-x64-gnu.$GLIBC_VERSION.node zen-engine.linux-x64-gnu.node
               strip zen-engine.linux-x64-gnu.node
 
@@ -83,7 +83,7 @@ jobs:
               rustup target add aarch64-unknown-linux-gnu
               mkdir -p ../../target
               ln -sfn aarch64-unknown-linux-gnu ../../target/aarch64-unknown-linux-gnu.$GLIBC_VERSION
-              yarn build --target aarch64-unknown-linux-gnu.$GLIBC_VERSION --cross-compile
+              yarn build --target aarch64-unknown-linux-gnu.$GLIBC_VERSION --cross-compile -- --locked
               mv -f zen-engine.linux-arm64-gnu.$GLIBC_VERSION.node zen-engine.linux-arm64-gnu.node
 
           - host: ubuntu-latest
@@ -92,7 +92,7 @@ jobs:
             build: |
               set -e
               rustup target add x86_64-unknown-linux-musl
-              yarn build --target x86_64-unknown-linux-musl --cross-compile
+              yarn build --target x86_64-unknown-linux-musl --cross-compile -- --locked
               strip ./*.node
 
           - host: ubuntu-latest
@@ -101,7 +101,7 @@ jobs:
             build: |
               set -e
               rustup target add aarch64-unknown-linux-musl
-              yarn build --target aarch64-unknown-linux-musl --cross-compile
+              yarn build --target aarch64-unknown-linux-musl --cross-compile -- --locked
 
           - host: ubuntu-latest
             target: 'wasm32-wasip1-threads'
@@ -114,7 +114,7 @@ jobs:
               export CMAKE_BUILD_PARALLEL_LEVEL=2
               export TARGET_CXXFLAGS="--target=wasm32-wasi-threads --sysroot=$(pwd)/wasi-sdk-27.0-x86_64-linux/share/wasi-sysroot -pthread -mllvm -wasm-enable-sjlj -lsetjmp"
               export TARGET_CFLAGS="$TARGET_CXXFLAGS"
-              yarn build --target wasm32-wasip1-threads
+              yarn build --target wasm32-wasip1-threads -- --locked
 
     name: stable - ${{ matrix.settings.target }} - node@22
     runs-on: ${{ matrix.settings.host }}

--- a/.github/workflows/node.yaml
+++ b/.github/workflows/node.yaml
@@ -69,8 +69,10 @@ jobs:
             build: |
               set -e
               rustup target add x86_64-unknown-linux-gnu
-              yarn build --target x86_64-unknown-linux-gnu.$GLIBC_VERSION --cross-compile -- -- --locked
+              cargo zigbuild -p zen-nodejs --release --locked --target x86_64-unknown-linux-gnu.$GLIBC_VERSION
+              cp ../../target/x86_64-unknown-linux-gnu/release/libzen_nodejs.so zen-engine.linux-x64-gnu.node
               strip zen-engine.linux-x64-gnu.node
+              echo "max glibc:"; readelf --dyn-syms zen-engine.linux-x64-gnu.node | grep -oE 'GLIBC_[0-9.]+' | sort -V | tail -1
 
           - host: ubuntu-latest
             target: 'aarch64-unknown-linux-gnu'
@@ -78,7 +80,9 @@ jobs:
             build: |
               set -e
               rustup target add aarch64-unknown-linux-gnu
-              yarn build --target aarch64-unknown-linux-gnu.$GLIBC_VERSION --cross-compile -- -- --locked
+              cargo zigbuild -p zen-nodejs --release --locked --target aarch64-unknown-linux-gnu.$GLIBC_VERSION
+              cp ../../target/aarch64-unknown-linux-gnu/release/libzen_nodejs.so zen-engine.linux-arm64-gnu.node
+              echo "max glibc:"; readelf --dyn-syms zen-engine.linux-arm64-gnu.node | grep -oE 'GLIBC_[0-9.]+' | sort -V | tail -1
 
           - host: ubuntu-latest
             target: 'x86_64-unknown-linux-musl'

--- a/.github/workflows/node.yaml
+++ b/.github/workflows/node.yaml
@@ -1,4 +1,5 @@
 name: NodeJS
+
 env:
   WORKING_DIRECTORY: bindings/nodejs
   DEBUG: 'napi:*'

--- a/.github/workflows/node.yaml
+++ b/.github/workflows/node.yaml
@@ -43,13 +43,13 @@ jobs:
           - host: windows-latest
             target: 'x86_64-pc-windows-msvc'
             build: |
-              yarn build --target x86_64-pc-windows-msvc -- --locked
+              yarn build --target x86_64-pc-windows-msvc -- -- --locked
 
           - host: macos-15-intel
             target: 'x86_64-apple-darwin'
             build: |
               rustup target add x86_64-apple-darwin
-              yarn build --target x86_64-apple-darwin -- --locked
+              yarn build --target x86_64-apple-darwin -- -- --locked
               strip -x ./*.node
 
           - host: macos-latest
@@ -60,7 +60,7 @@ jobs:
               export CXX=$(xcrun -f clang++);
               SYSROOT=$(xcrun --sdk macosx --show-sdk-path);
               export CFLAGS="-isysroot $SYSROOT -isystem $SYSROOT";
-              yarn build --target aarch64-apple-darwin -- --locked
+              yarn build --target aarch64-apple-darwin -- -- --locked
               strip -x ./*.node
 
           - host: ubuntu-latest
@@ -71,7 +71,7 @@ jobs:
               rustup target add x86_64-unknown-linux-gnu
               mkdir -p ../../target
               ln -sfn x86_64-unknown-linux-gnu ../../target/x86_64-unknown-linux-gnu.$GLIBC_VERSION
-              yarn build --target x86_64-unknown-linux-gnu.$GLIBC_VERSION --cross-compile -- --locked
+              yarn build --target x86_64-unknown-linux-gnu.$GLIBC_VERSION --cross-compile -- -- --locked
               mv -f zen-engine.linux-x64-gnu.$GLIBC_VERSION.node zen-engine.linux-x64-gnu.node
               strip zen-engine.linux-x64-gnu.node
 
@@ -83,7 +83,7 @@ jobs:
               rustup target add aarch64-unknown-linux-gnu
               mkdir -p ../../target
               ln -sfn aarch64-unknown-linux-gnu ../../target/aarch64-unknown-linux-gnu.$GLIBC_VERSION
-              yarn build --target aarch64-unknown-linux-gnu.$GLIBC_VERSION --cross-compile -- --locked
+              yarn build --target aarch64-unknown-linux-gnu.$GLIBC_VERSION --cross-compile -- -- --locked
               mv -f zen-engine.linux-arm64-gnu.$GLIBC_VERSION.node zen-engine.linux-arm64-gnu.node
 
           - host: ubuntu-latest
@@ -92,7 +92,7 @@ jobs:
             build: |
               set -e
               rustup target add x86_64-unknown-linux-musl
-              yarn build --target x86_64-unknown-linux-musl --cross-compile -- --locked
+              yarn build --target x86_64-unknown-linux-musl --cross-compile -- -- --locked
               strip ./*.node
 
           - host: ubuntu-latest
@@ -101,7 +101,7 @@ jobs:
             build: |
               set -e
               rustup target add aarch64-unknown-linux-musl
-              yarn build --target aarch64-unknown-linux-musl --cross-compile -- --locked
+              yarn build --target aarch64-unknown-linux-musl --cross-compile -- -- --locked
 
           - host: ubuntu-latest
             target: 'wasm32-wasip1-threads'
@@ -114,7 +114,7 @@ jobs:
               export CMAKE_BUILD_PARALLEL_LEVEL=2
               export TARGET_CXXFLAGS="--target=wasm32-wasi-threads --sysroot=$(pwd)/wasi-sdk-27.0-x86_64-linux/share/wasi-sysroot -pthread -mllvm -wasm-enable-sjlj -lsetjmp"
               export TARGET_CFLAGS="$TARGET_CXXFLAGS"
-              yarn build --target wasm32-wasip1-threads -- --locked
+              yarn build --target wasm32-wasip1-threads -- -- --locked
 
     name: stable - ${{ matrix.settings.target }} - node@22
     runs-on: ${{ matrix.settings.host }}

--- a/.github/workflows/node.yaml
+++ b/.github/workflows/node.yaml
@@ -43,13 +43,13 @@ jobs:
           - host: windows-latest
             target: 'x86_64-pc-windows-msvc'
             build: |
-              yarn build --target x86_64-pc-windows-msvc -- -- --locked
+              yarn build --target x86_64-pc-windows-msvc
 
           - host: macos-15-intel
             target: 'x86_64-apple-darwin'
             build: |
               rustup target add x86_64-apple-darwin
-              yarn build --target x86_64-apple-darwin -- -- --locked
+              yarn build --target x86_64-apple-darwin
               strip -x ./*.node
 
           - host: macos-latest
@@ -60,7 +60,7 @@ jobs:
               export CXX=$(xcrun -f clang++);
               SYSROOT=$(xcrun --sdk macosx --show-sdk-path);
               export CFLAGS="-isysroot $SYSROOT -isystem $SYSROOT";
-              yarn build --target aarch64-apple-darwin -- -- --locked
+              yarn build --target aarch64-apple-darwin
               strip -x ./*.node
 
           - host: ubuntu-latest
@@ -69,10 +69,11 @@ jobs:
             build: |
               set -e
               rustup target add x86_64-unknown-linux-gnu
-              cargo zigbuild -p zen-nodejs --release --locked --target x86_64-unknown-linux-gnu.$GLIBC_VERSION
-              cp ../../target/x86_64-unknown-linux-gnu/release/libzen_nodejs.so zen-engine.linux-x64-gnu.node
+              mkdir -p ../../target
+              ln -sfn x86_64-unknown-linux-gnu ../../target/x86_64-unknown-linux-gnu.$GLIBC_VERSION
+              yarn build --target x86_64-unknown-linux-gnu.$GLIBC_VERSION --cross-compile
+              mv -f zen-engine.linux-x64-gnu.$GLIBC_VERSION.node zen-engine.linux-x64-gnu.node
               strip zen-engine.linux-x64-gnu.node
-              echo "max glibc:"; readelf --dyn-syms zen-engine.linux-x64-gnu.node | grep -oE 'GLIBC_[0-9.]+' | sort -V | tail -1
 
           - host: ubuntu-latest
             target: 'aarch64-unknown-linux-gnu'
@@ -80,9 +81,10 @@ jobs:
             build: |
               set -e
               rustup target add aarch64-unknown-linux-gnu
-              cargo zigbuild -p zen-nodejs --release --locked --target aarch64-unknown-linux-gnu.$GLIBC_VERSION
-              cp ../../target/aarch64-unknown-linux-gnu/release/libzen_nodejs.so zen-engine.linux-arm64-gnu.node
-              echo "max glibc:"; readelf --dyn-syms zen-engine.linux-arm64-gnu.node | grep -oE 'GLIBC_[0-9.]+' | sort -V | tail -1
+              mkdir -p ../../target
+              ln -sfn aarch64-unknown-linux-gnu ../../target/aarch64-unknown-linux-gnu.$GLIBC_VERSION
+              yarn build --target aarch64-unknown-linux-gnu.$GLIBC_VERSION --cross-compile
+              mv -f zen-engine.linux-arm64-gnu.$GLIBC_VERSION.node zen-engine.linux-arm64-gnu.node
 
           - host: ubuntu-latest
             target: 'x86_64-unknown-linux-musl'
@@ -90,7 +92,7 @@ jobs:
             build: |
               set -e
               rustup target add x86_64-unknown-linux-musl
-              yarn build --target x86_64-unknown-linux-musl --cross-compile -- -- --locked
+              yarn build --target x86_64-unknown-linux-musl --cross-compile
               strip ./*.node
 
           - host: ubuntu-latest
@@ -99,7 +101,7 @@ jobs:
             build: |
               set -e
               rustup target add aarch64-unknown-linux-musl
-              yarn build --target aarch64-unknown-linux-musl --cross-compile -- -- --locked
+              yarn build --target aarch64-unknown-linux-musl --cross-compile
 
           - host: ubuntu-latest
             target: 'wasm32-wasip1-threads'
@@ -112,7 +114,7 @@ jobs:
               export CMAKE_BUILD_PARALLEL_LEVEL=2
               export TARGET_CXXFLAGS="--target=wasm32-wasi-threads --sysroot=$(pwd)/wasi-sdk-27.0-x86_64-linux/share/wasi-sysroot -pthread -mllvm -wasm-enable-sjlj -lsetjmp"
               export TARGET_CFLAGS="$TARGET_CXXFLAGS"
-              yarn build --target wasm32-wasip1-threads -- -- --locked
+              yarn build --target wasm32-wasip1-threads
 
     name: stable - ${{ matrix.settings.target }} - node@22
     runs-on: ${{ matrix.settings.host }}

--- a/.github/workflows/node.yaml
+++ b/.github/workflows/node.yaml
@@ -44,13 +44,13 @@ jobs:
           - host: windows-latest
             target: 'x86_64-pc-windows-msvc'
             build: |
-              yarn build --target x86_64-pc-windows-msvc -- -- --locked
+              yarn build -- --target x86_64-pc-windows-msvc -- --locked
 
           - host: macos-15-intel
             target: 'x86_64-apple-darwin'
             build: |
               rustup target add x86_64-apple-darwin
-              yarn build --target x86_64-apple-darwin -- -- --locked
+              yarn build -- --target x86_64-apple-darwin -- --locked
               strip -x ./*.node
 
           - host: macos-latest
@@ -61,7 +61,7 @@ jobs:
               export CXX=$(xcrun -f clang++);
               SYSROOT=$(xcrun --sdk macosx --show-sdk-path);
               export CFLAGS="-isysroot $SYSROOT -isystem $SYSROOT";
-              yarn build --target aarch64-apple-darwin -- -- --locked
+              yarn build -- --target aarch64-apple-darwin -- --locked
               strip -x ./*.node
 
           - host: ubuntu-latest
@@ -72,7 +72,7 @@ jobs:
               rustup target add x86_64-unknown-linux-gnu
               mkdir -p ../../target
               ln -sfn x86_64-unknown-linux-gnu ../../target/x86_64-unknown-linux-gnu.$GLIBC_VERSION
-              yarn build --target x86_64-unknown-linux-gnu.$GLIBC_VERSION --cross-compile -- -- --locked
+              yarn build -- --target x86_64-unknown-linux-gnu.$GLIBC_VERSION --cross-compile -- --locked
               mv -f zen-engine.linux-x64-gnu.$GLIBC_VERSION.node zen-engine.linux-x64-gnu.node
               strip zen-engine.linux-x64-gnu.node
 
@@ -84,7 +84,7 @@ jobs:
               rustup target add aarch64-unknown-linux-gnu
               mkdir -p ../../target
               ln -sfn aarch64-unknown-linux-gnu ../../target/aarch64-unknown-linux-gnu.$GLIBC_VERSION
-              yarn build --target aarch64-unknown-linux-gnu.$GLIBC_VERSION --cross-compile -- -- --locked
+              yarn build -- --target aarch64-unknown-linux-gnu.$GLIBC_VERSION --cross-compile -- --locked
               mv -f zen-engine.linux-arm64-gnu.$GLIBC_VERSION.node zen-engine.linux-arm64-gnu.node
 
           - host: ubuntu-latest
@@ -93,7 +93,7 @@ jobs:
             build: |
               set -e
               rustup target add x86_64-unknown-linux-musl
-              yarn build --target x86_64-unknown-linux-musl --cross-compile -- -- --locked
+              yarn build -- --target x86_64-unknown-linux-musl --cross-compile -- --locked
               strip ./*.node
 
           - host: ubuntu-latest
@@ -102,7 +102,7 @@ jobs:
             build: |
               set -e
               rustup target add aarch64-unknown-linux-musl
-              yarn build --target aarch64-unknown-linux-musl --cross-compile -- -- --locked
+              yarn build -- --target aarch64-unknown-linux-musl --cross-compile -- --locked
 
           - host: ubuntu-latest
             target: 'wasm32-wasip1-threads'
@@ -115,7 +115,7 @@ jobs:
               export CMAKE_BUILD_PARALLEL_LEVEL=2
               export TARGET_CXXFLAGS="--target=wasm32-wasi-threads --sysroot=$(pwd)/wasi-sdk-27.0-x86_64-linux/share/wasi-sysroot -pthread -mllvm -wasm-enable-sjlj -lsetjmp"
               export TARGET_CFLAGS="$TARGET_CXXFLAGS"
-              yarn build --target wasm32-wasip1-threads -- -- --locked
+              yarn build -- --target wasm32-wasip1-threads -- --locked
 
     name: stable - ${{ matrix.settings.target }} - node@22
     runs-on: ${{ matrix.settings.host }}

--- a/.github/workflows/node.yaml
+++ b/.github/workflows/node.yaml
@@ -44,13 +44,13 @@ jobs:
           - host: windows-latest
             target: 'x86_64-pc-windows-msvc'
             build: |
-              yarn build --target x86_64-pc-windows-msvc
+              yarn build --target x86_64-pc-windows-msvc -- -- --locked
 
           - host: macos-15-intel
             target: 'x86_64-apple-darwin'
             build: |
               rustup target add x86_64-apple-darwin
-              yarn build --target x86_64-apple-darwin
+              yarn build --target x86_64-apple-darwin -- -- --locked
               strip -x ./*.node
 
           - host: macos-latest
@@ -61,7 +61,7 @@ jobs:
               export CXX=$(xcrun -f clang++);
               SYSROOT=$(xcrun --sdk macosx --show-sdk-path);
               export CFLAGS="-isysroot $SYSROOT -isystem $SYSROOT";
-              yarn build --target aarch64-apple-darwin
+              yarn build --target aarch64-apple-darwin -- -- --locked
               strip -x ./*.node
 
           - host: ubuntu-latest
@@ -72,7 +72,7 @@ jobs:
               rustup target add x86_64-unknown-linux-gnu
               mkdir -p ../../target
               ln -sfn x86_64-unknown-linux-gnu ../../target/x86_64-unknown-linux-gnu.$GLIBC_VERSION
-              yarn build --target x86_64-unknown-linux-gnu.$GLIBC_VERSION --cross-compile
+              yarn build --target x86_64-unknown-linux-gnu.$GLIBC_VERSION --cross-compile -- -- --locked
               mv -f zen-engine.linux-x64-gnu.$GLIBC_VERSION.node zen-engine.linux-x64-gnu.node
               strip zen-engine.linux-x64-gnu.node
 
@@ -84,7 +84,7 @@ jobs:
               rustup target add aarch64-unknown-linux-gnu
               mkdir -p ../../target
               ln -sfn aarch64-unknown-linux-gnu ../../target/aarch64-unknown-linux-gnu.$GLIBC_VERSION
-              yarn build --target aarch64-unknown-linux-gnu.$GLIBC_VERSION --cross-compile
+              yarn build --target aarch64-unknown-linux-gnu.$GLIBC_VERSION --cross-compile -- -- --locked
               mv -f zen-engine.linux-arm64-gnu.$GLIBC_VERSION.node zen-engine.linux-arm64-gnu.node
 
           - host: ubuntu-latest
@@ -93,7 +93,7 @@ jobs:
             build: |
               set -e
               rustup target add x86_64-unknown-linux-musl
-              yarn build --target x86_64-unknown-linux-musl --cross-compile
+              yarn build --target x86_64-unknown-linux-musl --cross-compile -- -- --locked
               strip ./*.node
 
           - host: ubuntu-latest
@@ -102,7 +102,7 @@ jobs:
             build: |
               set -e
               rustup target add aarch64-unknown-linux-musl
-              yarn build --target aarch64-unknown-linux-musl --cross-compile
+              yarn build --target aarch64-unknown-linux-musl --cross-compile -- -- --locked
 
           - host: ubuntu-latest
             target: 'wasm32-wasip1-threads'
@@ -115,7 +115,7 @@ jobs:
               export CMAKE_BUILD_PARALLEL_LEVEL=2
               export TARGET_CXXFLAGS="--target=wasm32-wasi-threads --sysroot=$(pwd)/wasi-sdk-27.0-x86_64-linux/share/wasi-sysroot -pthread -mllvm -wasm-enable-sjlj -lsetjmp"
               export TARGET_CFLAGS="$TARGET_CXXFLAGS"
-              yarn build --target wasm32-wasip1-threads
+              yarn build --target wasm32-wasip1-threads -- -- --locked
 
     name: stable - ${{ matrix.settings.target }} - node@22
     runs-on: ${{ matrix.settings.host }}

--- a/.github/workflows/node.yaml
+++ b/.github/workflows/node.yaml
@@ -69,10 +69,7 @@ jobs:
             build: |
               set -e
               rustup target add x86_64-unknown-linux-gnu
-              mkdir -p ../../target
-              ln -sfn x86_64-unknown-linux-gnu ../../target/x86_64-unknown-linux-gnu.$GLIBC_VERSION
               yarn build --target x86_64-unknown-linux-gnu.$GLIBC_VERSION --cross-compile -- -- --locked
-              mv -f zen-engine.linux-x64-gnu.$GLIBC_VERSION.node zen-engine.linux-x64-gnu.node
               strip zen-engine.linux-x64-gnu.node
 
           - host: ubuntu-latest
@@ -81,10 +78,7 @@ jobs:
             build: |
               set -e
               rustup target add aarch64-unknown-linux-gnu
-              mkdir -p ../../target
-              ln -sfn aarch64-unknown-linux-gnu ../../target/aarch64-unknown-linux-gnu.$GLIBC_VERSION
               yarn build --target aarch64-unknown-linux-gnu.$GLIBC_VERSION --cross-compile -- -- --locked
-              mv -f zen-engine.linux-arm64-gnu.$GLIBC_VERSION.node zen-engine.linux-arm64-gnu.node
 
           - host: ubuntu-latest
             target: 'x86_64-unknown-linux-musl'

--- a/.github/workflows/python.yaml
+++ b/.github/workflows/python.yaml
@@ -40,26 +40,26 @@ jobs:
           - os: ubuntu-latest
             platform: linux
             target: x86_64
-            args: --release --out dist --find-interpreter -m bindings/python/Cargo.toml --zig --compatibility manylinux_2_28
+            args: --release --out dist --find-interpreter --locked -m bindings/python/Cargo.toml --zig --compatibility manylinux_2_28
             manylinux: auto
           - os: ubuntu-latest
             platform: linux
             target: aarch64
-            args: --release --out dist --find-interpreter -m bindings/python/Cargo.toml --zig --compatibility manylinux_2_28
+            args: --release --out dist --find-interpreter --locked -m bindings/python/Cargo.toml --zig --compatibility manylinux_2_28
             manylinux: auto
           - os: windows-latest
             platform: windows
             target: x64
             architecture: x64
-            args: --release --out dist --find-interpreter -m bindings/python/Cargo.toml
+            args: --release --out dist --find-interpreter --locked -m bindings/python/Cargo.toml
           - os: macos-latest
             platform: macos
             target: x86_64
-            args: --release --out dist --find-interpreter -m bindings/python/Cargo.toml
+            args: --release --out dist --find-interpreter --locked -m bindings/python/Cargo.toml
           - os: macos-latest
             platform: macos
             target: aarch64
-            args: --release --out dist --find-interpreter -m bindings/python/Cargo.toml
+            args: --release --out dist --find-interpreter --locked -m bindings/python/Cargo.toml
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v4

--- a/.github/workflows/release-please.yaml
+++ b/.github/workflows/release-please.yaml
@@ -37,8 +37,29 @@ jobs:
     name: Release Please
     runs-on: ubuntu-latest
     steps:
-      - uses: googleapis/release-please-action@v4
+      - uses: googleapis/release-please-action@v5
+        id: release
         with:
           token: ${{ secrets.PAT }}
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json
+
+      - uses: actions/checkout@v4
+        if: steps.release.outputs.pr
+        with:
+          ref: ${{ fromJSON(steps.release.outputs.pr).headBranchName }}
+          token: ${{ secrets.PAT }}
+
+      - uses: dtolnay/rust-toolchain@stable
+        if: steps.release.outputs.pr
+
+      - name: Update Cargo.lock on release PR
+        if: steps.release.outputs.pr
+        run: |
+          cargo update --workspace
+          git diff --quiet Cargo.lock && exit 0
+          git config user.name "Bot GoRules"
+          git config user.email "bot@gorules.io"
+          git add Cargo.lock
+          git commit -m "chore: update Cargo.lock for release"
+          git push

--- a/.github/workflows/rust.yaml
+++ b/.github/workflows/rust.yaml
@@ -55,9 +55,9 @@ jobs:
       - uses: ./.github/actions/setup-rust
         with:
           shared-key: rust-test-${{ matrix.os }}
-      - run: cargo test --workspace --all-features --exclude zen-ffi --exclude zen-nodejs --exclude zen-python
+      - run: cargo test --workspace --all-features --exclude zen-ffi --exclude zen-nodejs --exclude zen-python --locked
       - name: Test without arbitrary_precision
-        run: cargo test --workspace --exclude zen-ffi --exclude zen-nodejs --exclude zen-python
+        run: cargo test --workspace --exclude zen-ffi --exclude zen-nodejs --exclude zen-python --locked
 
   fmt:
     name: Cargo FMT
@@ -87,16 +87,16 @@ jobs:
         run: cargo login ${{ secrets.CRATES_TOKEN }}
 
       - name: Publish Macros
-        run: cd core/macros && cargo publish
+        run: cd core/macros && cargo publish --locked
 
       - name: Publish Types
-        run: cd core/types && cargo publish
+        run: cd core/types && cargo publish --locked
 
       - name: Publish Expression
-        run: cd core/expression && cargo publish
+        run: cd core/expression && cargo publish --locked
 
       - name: Publish Template
-        run: cd core/template && cargo publish
+        run: cd core/template && cargo publish --locked
 
       - name: Publish Engine
-        run: cd core/engine && cargo publish
+        run: cd core/engine && cargo publish --locked

--- a/.github/workflows/uniffi.yaml
+++ b/.github/workflows/uniffi.yaml
@@ -80,14 +80,14 @@ jobs:
       - name: Build (zig, linux)
         if: ${{ matrix.settings.host == 'ubuntu-latest' }}
         working-directory: ${{ env.UNIFFI_DIRECTORY }}
-        run: cargo zigbuild --lib --release --target ${{ matrix.settings.target }}.${{ env.GLIBC_VERSION }} ${{ matrix.settings.extra_args }}
+        run: cargo zigbuild --lib --release --locked --target ${{ matrix.settings.target }}.${{ env.GLIBC_VERSION }} ${{ matrix.settings.extra_args }}
       - name: Build (native)
         if: ${{ matrix.settings.host != 'ubuntu-latest' }}
         uses: houseabsolute/actions-rust-cross@v1
         with:
           working-directory: ${{ env.UNIFFI_DIRECTORY }}
           target: ${{ matrix.settings.target }}
-          args: '--lib --release ${{ matrix.settings.extra_args }}'
+          args: '--lib --release --locked ${{ matrix.settings.extra_args }}'
 
       - name: Upload artifact
         uses: actions/upload-artifact@v4
@@ -133,7 +133,7 @@ jobs:
 
       - name: Generate Kotlin sources
         run: |
-          cargo run --bin uniffi-bindgen -- generate \
+          cargo run --locked --bin uniffi-bindgen -- generate \
             --library build/generated/resources/darwin-x86-64/libzen_uniffi.dylib \
             --language kotlin \
             --out-dir build/generated/kotlin
@@ -294,7 +294,7 @@ jobs:
           if [ "${{ matrix.settings.target }}" = "aarch64-apple-ios-sim" ]; then
             export BINDGEN_EXTRA_CLANG_ARGS="--target=aarch64-apple-ios --sysroot=$(xcrun --sdk iphonesimulator --show-sdk-path)"
           fi
-          cargo build -p zen-uniffi --target ${{ matrix.settings.target }} --release --features bindgen
+          cargo build -p zen-uniffi --target ${{ matrix.settings.target }} --release --locked --features bindgen
 
       - name: Upload artifact
         uses: actions/upload-artifact@v4
@@ -335,7 +335,7 @@ jobs:
 
       - name: Generate Swift bindings
         run: |
-          cargo run --bin uniffi-bindgen -- generate \
+          cargo run --locked --bin uniffi-bindgen -- generate \
             --library target/aarch64-apple-ios/release/libzen_uniffi.a \
             --language swift \
             --out-dir swift-bindings-temp
@@ -524,7 +524,7 @@ jobs:
           cargo ndk -t arm64-v8a -t armeabi-v7a -t x86 -t x86_64 \
            --platform 33 \
            -o ./android-libs \
-           build -p zen-uniffi --release --features bindgen
+           build -p zen-uniffi --release --locked --features bindgen
 
       - name: Build for Android (arm64 only)
         if: "github.event_name != 'release' || !startsWith(github.event.release.tag_name, 'uniffi-v')"
@@ -534,7 +534,7 @@ jobs:
           cargo ndk -t arm64-v8a \
            --platform 33 \
            -o ./android-libs \
-           build -p zen-uniffi --release --features bindgen
+           build -p zen-uniffi --release --locked --features bindgen
 
       - name: Upload Android artifacts
         uses: actions/upload-artifact@v4
@@ -565,7 +565,7 @@ jobs:
 
       - name: Generate Kotlin sources
         run: |
-          cargo run --bin uniffi-bindgen -- generate \
+          cargo run --locked --bin uniffi-bindgen -- generate \
             --library build/generated/resources/darwin-x86-64/libzen_uniffi.dylib \
             --language kotlin \
             --config uniffi-android.toml \

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -1,9 +1,9 @@
 {
   "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json",
-  "separate-pull-requests": true,
+  "separate-pull-requests": false,
   "include-component-in-tag": true,
   "tag-separator": "-",
-  "pull-request-title-pattern": "chore(release): ${component} ${version}",
+  "pull-request-title-pattern": "chore(release): publish",
   "release-as": "1.0.0-beta.0",
   "prerelease": true,
   "prerelease-type": "beta",


### PR DESCRIPTION
Makes release builds reproducible and fixes release-please's lockfile handling.

- **`--locked` everywhere** - every workspace-compiling command (rust, node, python, uniffi, go, miri) now enforces the committed `Cargo.lock`.
- **Auto-sync `Cargo.lock` on release PRs** - release-please bumps `Cargo.toml` but skips the lockfile when the `cargo-workspace` plugin is on ([#2517](https://github.com/googleapis/release-please/issues/2517)), so a step now runs `cargo update --workspace` and commits the synced lock - keeping `--locked` builds green. Action bumped to **v5**.
- **One combined release PR** -`separate-pull-requests: false` (component versions stay independent).
