### PR TITLE
chore: add s3 backend for sccache

### DIFF
--- a/.github/actions/setup-rust/action.yml
+++ b/.github/actions/setup-rust/action.yml
@@ -1,5 +1,5 @@
 name: 'Setup Rust caching'
-description: 'Swatinem/rust-cache + sccache.'
+description: 'Swatinem/rust-cache + sccache (s3 backend via oidc, gha fallback).'
 
 inputs:
   shared-key:
@@ -18,6 +18,18 @@ inputs:
     description: 'Enable sccache as RUSTC_WRAPPER.'
     required: false
     default: 'true'
+  sccache-bucket:
+    description: 'S3 bucket for the sccache backend.'
+    required: false
+    default: ''
+  sccache-region:
+    description: 'AWS region for the sccache S3 bucket.'
+    required: false
+    default: ''
+  sccache-role-arn:
+    description: 'IAM role ARN to assume via OIDC for sccache S3 access.'
+    required: false
+    default: ''
   zig:
     description: 'Install ziglang + cargo-zigbuild.'
     required: false
@@ -50,8 +62,24 @@ runs:
       if: ${{ inputs.sccache == 'true' && github.ref_type != 'tag' }}
       uses: mozilla-actions/sccache-action@v0.0.10
 
-    - name: Enable sccache
-      if: ${{ inputs.sccache == 'true' && github.ref_type != 'tag' }}
+    - name: Configure aws credentials for sccache
+      if: ${{ inputs.sccache == 'true' && github.ref_type != 'tag' && inputs.sccache-bucket != '' && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) }}
+      uses: aws-actions/configure-aws-credentials@v6
+      with:
+        role-to-assume: ${{ inputs.sccache-role-arn }}
+        aws-region: ${{ inputs.sccache-region }}
+
+    - name: Enable sccache (s3)
+      if: ${{ inputs.sccache == 'true' && github.ref_type != 'tag' && inputs.sccache-bucket != '' && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) }}
+      shell: bash
+      run: |
+        echo "SCCACHE_BUCKET=${{ inputs.sccache-bucket }}" >> "$GITHUB_ENV"
+        echo "SCCACHE_REGION=${{ inputs.sccache-region }}" >> "$GITHUB_ENV"
+        echo "SCCACHE_S3_KEY_PREFIX=zen" >> "$GITHUB_ENV"
+        echo "RUSTC_WRAPPER=sccache" >> "$GITHUB_ENV"
+
+    - name: Enable sccache (gha fallback)
+      if: ${{ inputs.sccache == 'true' && github.ref_type != 'tag' && (inputs.sccache-bucket == '' || (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository)) }}
       shell: bash
       run: |
         echo "SCCACHE_GHA_ENABLED=true" >> "$GITHUB_ENV"

--- a/.github/workflows/go.yaml
+++ b/.github/workflows/go.yaml
@@ -51,6 +51,9 @@ jobs:
         with:
           shared-key: go-${{ matrix.settings.target }}
           zig: ${{ matrix.settings.host == 'ubuntu-latest' }}
+          sccache-bucket: ${{ secrets.SCCACHE_S3_BUCKET }}
+          sccache-region: ${{ secrets.SCCACHE_AWS_REGION }}
+          sccache-role-arn: ${{ secrets.SCCACHE_AWS_ROLE_ARN }}
 
       - name: Build (zig, linux)
         if: ${{ matrix.settings.host == 'ubuntu-latest' }}

--- a/.github/workflows/node.yaml
+++ b/.github/workflows/node.yaml
@@ -21,6 +21,7 @@ on:
 
 permissions:
   contents: write
+  id-token: write
 
 jobs:
   build:
@@ -133,6 +134,9 @@ jobs:
           shared-key: nodejs-${{ matrix.settings.target }}
           key: ${{ matrix.settings.target }}
           zig: ${{ matrix.settings.zig }}
+          sccache-bucket: ${{ secrets.SCCACHE_S3_BUCKET }}
+          sccache-region: ${{ secrets.SCCACHE_AWS_REGION }}
+          sccache-role-arn: ${{ secrets.SCCACHE_AWS_ROLE_ARN }}
 
       - name: Setup toolchain
         run: ${{ matrix.settings.setup }}

--- a/.github/workflows/rust.yaml
+++ b/.github/workflows/rust.yaml
@@ -2,6 +2,7 @@ name: Rust
 
 permissions:
   contents: read
+  id-token: write
 
 on:
   pull_request:
@@ -44,6 +45,9 @@ jobs:
       - uses: ./.github/actions/setup-rust
         with:
           shared-key: rust-test-${{ matrix.os }}
+          sccache-bucket: ${{ secrets.SCCACHE_S3_BUCKET }}
+          sccache-region: ${{ secrets.SCCACHE_AWS_REGION }}
+          sccache-role-arn: ${{ secrets.SCCACHE_AWS_ROLE_ARN }}
       - run: cargo test --workspace --all-features --exclude zen-ffi --exclude zen-nodejs --exclude zen-python --locked
       - name: Test without arbitrary_precision
         run: cargo test --workspace --exclude zen-ffi --exclude zen-nodejs --exclude zen-python --locked

--- a/.github/workflows/uniffi.yaml
+++ b/.github/workflows/uniffi.yaml
@@ -15,6 +15,9 @@ on:
 
 jobs:
   build:
+    permissions:
+      contents: read
+      id-token: write
     env:
       OUTPUT_NAME: zen_uniffi
 
@@ -63,6 +66,9 @@ jobs:
         with:
           shared-key: uniffi-${{ matrix.settings.target }}
           zig: ${{ matrix.settings.host == 'ubuntu-latest' }}
+          sccache-bucket: ${{ secrets.SCCACHE_S3_BUCKET }}
+          sccache-region: ${{ secrets.SCCACHE_AWS_REGION }}
+          sccache-role-arn: ${{ secrets.SCCACHE_AWS_ROLE_ARN }}
 
       # Linux targets (incl. s390x) build on the host via zig; mac/windows build natively.
       - name: Build (zig, linux)
@@ -243,6 +249,9 @@ jobs:
             --skip-duplicate
 
   build-ios:
+    permissions:
+      contents: read
+      id-token: write
     env:
       OUTPUT_NAME: zen_uniffi
       IPHONEOS_DEPLOYMENT_TARGET: '16.0'
@@ -275,6 +284,9 @@ jobs:
       - uses: ./.github/actions/setup-rust
         with:
           shared-key: uniffi-ios-${{ matrix.settings.target }}
+          sccache-bucket: ${{ secrets.SCCACHE_S3_BUCKET }}
+          sccache-region: ${{ secrets.SCCACHE_AWS_REGION }}
+          sccache-role-arn: ${{ secrets.SCCACHE_AWS_ROLE_ARN }}
 
       - name: Build iOS
         run: |
@@ -293,6 +305,9 @@ jobs:
   create-xcframework:
     runs-on: macos-latest
     needs: [ build-ios ]
+    permissions:
+      contents: read
+      id-token: write
 
     steps:
       - uses: actions/checkout@v3
@@ -303,6 +318,9 @@ jobs:
       - uses: ./.github/actions/setup-rust
         with:
           shared-key: uniffi-swift
+          sccache-bucket: ${{ secrets.SCCACHE_S3_BUCKET }}
+          sccache-region: ${{ secrets.SCCACHE_AWS_REGION }}
+          sccache-role-arn: ${{ secrets.SCCACHE_AWS_ROLE_ARN }}
 
       - name: Download iOS artifacts
         uses: actions/download-artifact@v4
@@ -465,6 +483,9 @@ jobs:
 
   build-android:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
     env:
       OUTPUT_NAME: zen_uniffi
 
@@ -477,6 +498,9 @@ jobs:
       - uses: ./.github/actions/setup-rust
         with:
           shared-key: uniffi-android
+          sccache-bucket: ${{ secrets.SCCACHE_S3_BUCKET }}
+          sccache-region: ${{ secrets.SCCACHE_AWS_REGION }}
+          sccache-role-arn: ${{ secrets.SCCACHE_AWS_ROLE_ARN }}
 
       - name: Install cargo-ndk
         run: cargo install cargo-ndk

--- a/core/engine/src/lib.rs
+++ b/core/engine/src/lib.rs
@@ -1,6 +1,6 @@
 //! # ZEN Engine
 //!
-//! ZEN Engine is business friendly Open-Source Business Rules Engine (BRE) which executes decision
+//! ZEN Engine is business-friendly Open-Source Business Rules Engine (BRE) which executes decision
 //! models according to the GoRules JSON Decision Model (JDM) standard. It's written in Rust and
 //! provides native bindings for NodeJS and Python.
 //!


### PR DESCRIPTION
switches the sccache backend from the gha cache to an s3 bucket using github oidc

falls back to the gha cache when the secrets are unset or on fork prs