### PR TITLE
fix: uniffi add additional config fields

### DIFF
--- a/bindings/uniffi/src/config.rs
+++ b/bindings/uniffi/src/config.rs
@@ -4,11 +4,23 @@ use zen_engine::ZEN_CONFIG;
 #[derive(uniffi::Record)]
 pub struct ZenConfig {
     pub nodes_in_context: Option<bool>,
+    pub function_timeout_millis: Option<u32>,
+    pub http_auth: Option<bool>,
 }
 
 #[uniffi::export]
 pub fn override_config(config: ZenConfig) {
     if let Some(val) = config.nodes_in_context {
-        ZEN_CONFIG.nodes_in_context.store(val, Ordering::Relaxed)
+        ZEN_CONFIG.nodes_in_context.store(val, Ordering::Relaxed);
+    }
+
+    if let Some(val) = config.function_timeout_millis {
+        ZEN_CONFIG
+            .function_timeout_millis
+            .store(val as u64, Ordering::Relaxed);
+    }
+
+    if let Some(val) = config.http_auth {
+        ZEN_CONFIG.http_auth.store(val, Ordering::Relaxed);
     }
 }


### PR DESCRIPTION
The uniffi ZenConfig only had `nodesInContext`. Added the other two fields the core already supports, so they can be set through overrideConfig like in the Node binding. Useful for bumping the function node timeout off the 5s default.