### PR TITLE
perf: binding variable conversion (python and nodejs)

### DIFF
--- a/bindings/nodejs/index.js
+++ b/bindings/nodejs/index.js
@@ -77,8 +77,8 @@ function requireNative() {
       try {
         const binding = require('@gorules/zen-engine-android-arm64')
         const bindingPackageVersion = require('@gorules/zen-engine-android-arm64/package.json').version
-        if (bindingPackageVersion !== '0.54.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.54.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '1.0.0-beta.2' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 1.0.0-beta.2 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -93,8 +93,8 @@ function requireNative() {
       try {
         const binding = require('@gorules/zen-engine-android-arm-eabi')
         const bindingPackageVersion = require('@gorules/zen-engine-android-arm-eabi/package.json').version
-        if (bindingPackageVersion !== '0.54.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.54.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '1.0.0-beta.2' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 1.0.0-beta.2 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -114,8 +114,8 @@ function requireNative() {
       try {
         const binding = require('@gorules/zen-engine-win32-x64-gnu')
         const bindingPackageVersion = require('@gorules/zen-engine-win32-x64-gnu/package.json').version
-        if (bindingPackageVersion !== '0.54.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.54.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '1.0.0-beta.2' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 1.0.0-beta.2 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -130,8 +130,8 @@ function requireNative() {
       try {
         const binding = require('@gorules/zen-engine-win32-x64-msvc')
         const bindingPackageVersion = require('@gorules/zen-engine-win32-x64-msvc/package.json').version
-        if (bindingPackageVersion !== '0.54.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.54.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '1.0.0-beta.2' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 1.0.0-beta.2 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -147,8 +147,8 @@ function requireNative() {
       try {
         const binding = require('@gorules/zen-engine-win32-ia32-msvc')
         const bindingPackageVersion = require('@gorules/zen-engine-win32-ia32-msvc/package.json').version
-        if (bindingPackageVersion !== '0.54.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.54.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '1.0.0-beta.2' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 1.0.0-beta.2 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -163,8 +163,8 @@ function requireNative() {
       try {
         const binding = require('@gorules/zen-engine-win32-arm64-msvc')
         const bindingPackageVersion = require('@gorules/zen-engine-win32-arm64-msvc/package.json').version
-        if (bindingPackageVersion !== '0.54.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.54.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '1.0.0-beta.2' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 1.0.0-beta.2 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -182,8 +182,8 @@ function requireNative() {
     try {
       const binding = require('@gorules/zen-engine-darwin-universal')
       const bindingPackageVersion = require('@gorules/zen-engine-darwin-universal/package.json').version
-      if (bindingPackageVersion !== '0.54.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-        throw new Error(`Native binding package version mismatch, expected 0.54.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+      if (bindingPackageVersion !== '1.0.0-beta.2' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+        throw new Error(`Native binding package version mismatch, expected 1.0.0-beta.2 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
       }
       return binding
     } catch (e) {
@@ -198,8 +198,8 @@ function requireNative() {
       try {
         const binding = require('@gorules/zen-engine-darwin-x64')
         const bindingPackageVersion = require('@gorules/zen-engine-darwin-x64/package.json').version
-        if (bindingPackageVersion !== '0.54.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.54.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '1.0.0-beta.2' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 1.0.0-beta.2 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -214,8 +214,8 @@ function requireNative() {
       try {
         const binding = require('@gorules/zen-engine-darwin-arm64')
         const bindingPackageVersion = require('@gorules/zen-engine-darwin-arm64/package.json').version
-        if (bindingPackageVersion !== '0.54.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.54.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '1.0.0-beta.2' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 1.0.0-beta.2 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -234,8 +234,8 @@ function requireNative() {
       try {
         const binding = require('@gorules/zen-engine-freebsd-x64')
         const bindingPackageVersion = require('@gorules/zen-engine-freebsd-x64/package.json').version
-        if (bindingPackageVersion !== '0.54.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.54.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '1.0.0-beta.2' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 1.0.0-beta.2 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -250,8 +250,8 @@ function requireNative() {
       try {
         const binding = require('@gorules/zen-engine-freebsd-arm64')
         const bindingPackageVersion = require('@gorules/zen-engine-freebsd-arm64/package.json').version
-        if (bindingPackageVersion !== '0.54.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.54.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '1.0.0-beta.2' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 1.0.0-beta.2 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -271,8 +271,8 @@ function requireNative() {
         try {
           const binding = require('@gorules/zen-engine-linux-x64-musl')
           const bindingPackageVersion = require('@gorules/zen-engine-linux-x64-musl/package.json').version
-          if (bindingPackageVersion !== '0.54.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.54.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '1.0.0-beta.2' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 1.0.0-beta.2 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -287,8 +287,8 @@ function requireNative() {
         try {
           const binding = require('@gorules/zen-engine-linux-x64-gnu')
           const bindingPackageVersion = require('@gorules/zen-engine-linux-x64-gnu/package.json').version
-          if (bindingPackageVersion !== '0.54.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.54.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '1.0.0-beta.2' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 1.0.0-beta.2 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -305,8 +305,8 @@ function requireNative() {
         try {
           const binding = require('@gorules/zen-engine-linux-arm64-musl')
           const bindingPackageVersion = require('@gorules/zen-engine-linux-arm64-musl/package.json').version
-          if (bindingPackageVersion !== '0.54.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.54.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '1.0.0-beta.2' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 1.0.0-beta.2 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -321,8 +321,8 @@ function requireNative() {
         try {
           const binding = require('@gorules/zen-engine-linux-arm64-gnu')
           const bindingPackageVersion = require('@gorules/zen-engine-linux-arm64-gnu/package.json').version
-          if (bindingPackageVersion !== '0.54.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.54.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '1.0.0-beta.2' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 1.0.0-beta.2 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -339,8 +339,8 @@ function requireNative() {
         try {
           const binding = require('@gorules/zen-engine-linux-arm-musleabihf')
           const bindingPackageVersion = require('@gorules/zen-engine-linux-arm-musleabihf/package.json').version
-          if (bindingPackageVersion !== '0.54.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.54.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '1.0.0-beta.2' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 1.0.0-beta.2 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -355,8 +355,8 @@ function requireNative() {
         try {
           const binding = require('@gorules/zen-engine-linux-arm-gnueabihf')
           const bindingPackageVersion = require('@gorules/zen-engine-linux-arm-gnueabihf/package.json').version
-          if (bindingPackageVersion !== '0.54.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.54.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '1.0.0-beta.2' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 1.0.0-beta.2 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -373,8 +373,8 @@ function requireNative() {
         try {
           const binding = require('@gorules/zen-engine-linux-loong64-musl')
           const bindingPackageVersion = require('@gorules/zen-engine-linux-loong64-musl/package.json').version
-          if (bindingPackageVersion !== '0.54.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.54.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '1.0.0-beta.2' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 1.0.0-beta.2 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -389,8 +389,8 @@ function requireNative() {
         try {
           const binding = require('@gorules/zen-engine-linux-loong64-gnu')
           const bindingPackageVersion = require('@gorules/zen-engine-linux-loong64-gnu/package.json').version
-          if (bindingPackageVersion !== '0.54.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.54.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '1.0.0-beta.2' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 1.0.0-beta.2 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -407,8 +407,8 @@ function requireNative() {
         try {
           const binding = require('@gorules/zen-engine-linux-riscv64-musl')
           const bindingPackageVersion = require('@gorules/zen-engine-linux-riscv64-musl/package.json').version
-          if (bindingPackageVersion !== '0.54.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.54.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '1.0.0-beta.2' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 1.0.0-beta.2 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -423,8 +423,8 @@ function requireNative() {
         try {
           const binding = require('@gorules/zen-engine-linux-riscv64-gnu')
           const bindingPackageVersion = require('@gorules/zen-engine-linux-riscv64-gnu/package.json').version
-          if (bindingPackageVersion !== '0.54.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.54.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '1.0.0-beta.2' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 1.0.0-beta.2 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -440,8 +440,8 @@ function requireNative() {
       try {
         const binding = require('@gorules/zen-engine-linux-ppc64-gnu')
         const bindingPackageVersion = require('@gorules/zen-engine-linux-ppc64-gnu/package.json').version
-        if (bindingPackageVersion !== '0.54.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.54.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '1.0.0-beta.2' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 1.0.0-beta.2 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -456,8 +456,8 @@ function requireNative() {
       try {
         const binding = require('@gorules/zen-engine-linux-s390x-gnu')
         const bindingPackageVersion = require('@gorules/zen-engine-linux-s390x-gnu/package.json').version
-        if (bindingPackageVersion !== '0.54.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.54.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '1.0.0-beta.2' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 1.0.0-beta.2 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -476,8 +476,8 @@ function requireNative() {
       try {
         const binding = require('@gorules/zen-engine-openharmony-arm64')
         const bindingPackageVersion = require('@gorules/zen-engine-openharmony-arm64/package.json').version
-        if (bindingPackageVersion !== '0.54.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.54.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '1.0.0-beta.2' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 1.0.0-beta.2 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -492,8 +492,8 @@ function requireNative() {
       try {
         const binding = require('@gorules/zen-engine-openharmony-x64')
         const bindingPackageVersion = require('@gorules/zen-engine-openharmony-x64/package.json').version
-        if (bindingPackageVersion !== '0.54.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.54.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '1.0.0-beta.2' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 1.0.0-beta.2 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -508,8 +508,8 @@ function requireNative() {
       try {
         const binding = require('@gorules/zen-engine-openharmony-arm')
         const bindingPackageVersion = require('@gorules/zen-engine-openharmony-arm/package.json').version
-        if (bindingPackageVersion !== '0.54.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.54.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '1.0.0-beta.2' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 1.0.0-beta.2 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {

--- a/bindings/nodejs/src/convert.rs
+++ b/bindings/nodejs/src/convert.rs
@@ -1,0 +1,255 @@
+use std::collections::HashMap;
+use std::os::raw::c_char;
+use std::ptr;
+use std::rc::Rc;
+
+use napi::bindgen_prelude::ToNapiValue;
+use napi::sys;
+use napi::sys::{napi_env, napi_value};
+use serde_json::Value;
+use zen_engine::{DecisionGraphResponse, EvaluationTrace, EvaluationTraceKind};
+use zen_expression::variable::ToVariable;
+use zen_expression::Variable;
+
+enum PNode {
+    Null,
+    Bool(bool),
+    Num(f64),
+    Str(Box<str>),
+    Arr(Vec<u32>),
+    Obj(Vec<(Box<str>, u32)>),
+    Json(Value),
+}
+
+pub struct PortableArena {
+    nodes: Vec<PNode>,
+}
+
+impl PortableArena {
+    pub fn new() -> Self {
+        Self { nodes: Vec::new() }
+    }
+
+    pub fn add(&mut self, var: &Variable, memo: &mut HashMap<usize, u32>) -> u32 {
+        let addr = match var {
+            Variable::Array(a) => Some(Rc::as_ptr(a) as *const () as usize),
+            Variable::Object(o) => Some(Rc::as_ptr(o) as *const () as usize),
+            _ => None,
+        };
+
+        if let Some(addr) = addr {
+            if let Some(id) = memo.get(&addr) {
+                return *id;
+            }
+        }
+
+        let node = match var {
+            Variable::Null => PNode::Null,
+            Variable::Bool(b) => PNode::Bool(*b),
+            Variable::Number(n) => {
+                PNode::Num(n.normalize().to_string().parse::<f64>().unwrap_or(f64::NAN))
+            }
+            Variable::String(s) => PNode::Str(Box::from(s.as_ref())),
+            Variable::Array(a) => {
+                let borrowed = a.borrow();
+                let mut children = Vec::with_capacity(borrowed.len());
+                for item in borrowed.iter() {
+                    children.push(self.add(item, memo));
+                }
+
+                PNode::Arr(children)
+            }
+            Variable::Object(o) => {
+                let borrowed = o.borrow();
+                let mut entries = Vec::with_capacity(borrowed.len());
+                for (key, value) in borrowed.iter() {
+                    let child = self.add(value, memo);
+                    entries.push((Box::from(key.as_ref()), child));
+                }
+
+                PNode::Obj(entries)
+            }
+            Variable::Dynamic(d) => PNode::Json(d.to_value()),
+        };
+
+        let id = self.nodes.len() as u32;
+        self.nodes.push(node);
+        if let Some(addr) = addr {
+            memo.insert(addr, id);
+        }
+
+        id
+    }
+}
+
+pub enum TraceField {
+    None,
+    Arena(u32),
+    Json(Value),
+}
+
+pub struct NodeEvalResponse {
+    pub performance: String,
+    pub arena: PortableArena,
+    pub result_root: u32,
+    pub trace: TraceField,
+}
+
+impl NodeEvalResponse {
+    pub fn build(response: DecisionGraphResponse, mode: EvaluationTraceKind) -> Self {
+        let mut arena = PortableArena::new();
+        let mut memo = HashMap::new();
+
+        let result_root = arena.add(&response.result, &mut memo);
+
+        let trace = match response.trace {
+            None => TraceField::None,
+            Some(EvaluationTrace::Graph(graph)) => {
+                let variable = graph.to_variable();
+                match mode {
+                    EvaluationTraceKind::Default => {
+                        TraceField::Arena(arena.add(&variable, &mut memo))
+                    }
+                    other => TraceField::Json(other.serialize_trace(&variable)),
+                }
+            }
+            Some(EvaluationTrace::Policy(policy)) => {
+                let value = match mode {
+                    EvaluationTraceKind::String | EvaluationTraceKind::ReferenceString => {
+                        Value::String(serde_json::to_string(&policy).unwrap_or_default())
+                    }
+                    _ => serde_json::to_value(&policy).unwrap_or_default(),
+                };
+
+                TraceField::Json(value)
+            }
+        };
+
+        Self {
+            performance: response.performance,
+            arena,
+            result_root,
+            trace,
+        }
+    }
+}
+
+struct Materializer<'a> {
+    env: napi_env,
+    nodes: &'a [PNode],
+    cache: Vec<napi_value>,
+    keys: HashMap<&'a str, napi_value>,
+}
+
+impl<'a> Materializer<'a> {
+    unsafe fn string(&self, s: &str) -> napi_value {
+        let mut out = ptr::null_mut();
+        sys::napi_create_string_utf8(
+            self.env,
+            s.as_ptr() as *const c_char,
+            s.len() as isize,
+            &mut out,
+        );
+        out
+    }
+
+    unsafe fn intern_key(&mut self, key: &'a str) -> napi_value {
+        if let Some(existing) = self.keys.get(key) {
+            return *existing;
+        }
+
+        let created = self.string(key);
+        self.keys.insert(key, created);
+        created
+    }
+
+    unsafe fn value(&mut self, id: u32) -> napi::Result<napi_value> {
+        let cached = self.cache[id as usize];
+        if !cached.is_null() {
+            return Ok(cached);
+        }
+
+        let built = self.build(id)?;
+        self.cache[id as usize] = built;
+        Ok(built)
+    }
+
+    unsafe fn build(&mut self, id: u32) -> napi::Result<napi_value> {
+        let nodes = self.nodes;
+        match &nodes[id as usize] {
+            PNode::Null => {
+                let mut out = ptr::null_mut();
+                sys::napi_get_null(self.env, &mut out);
+                Ok(out)
+            }
+            PNode::Bool(b) => {
+                let mut out = ptr::null_mut();
+                sys::napi_get_boolean(self.env, *b, &mut out);
+                Ok(out)
+            }
+            PNode::Num(n) => {
+                let mut out = ptr::null_mut();
+                sys::napi_create_double(self.env, *n, &mut out);
+                Ok(out)
+            }
+            PNode::Str(s) => Ok(self.string(s)),
+            PNode::Arr(children) => {
+                let mut arr = ptr::null_mut();
+                sys::napi_create_array_with_length(self.env, children.len(), &mut arr);
+                for (index, child) in children.iter().enumerate() {
+                    let value = self.value(*child)?;
+                    sys::napi_set_element(self.env, arr, index as u32, value);
+                }
+
+                Ok(arr)
+            }
+            PNode::Obj(entries) => {
+                let mut obj = ptr::null_mut();
+                sys::napi_create_object(self.env, &mut obj);
+                for (key, child) in entries.iter() {
+                    let key_value = self.intern_key(key);
+                    let value = self.value(*child)?;
+                    sys::napi_set_property(self.env, obj, key_value, value);
+                }
+
+                Ok(obj)
+            }
+            PNode::Json(value) => ToNapiValue::to_napi_value(self.env, value.clone()),
+        }
+    }
+}
+
+impl ToNapiValue for NodeEvalResponse {
+    unsafe fn to_napi_value(env: napi_env, val: Self) -> napi::Result<napi_value> {
+        let mut materializer = Materializer {
+            env,
+            nodes: &val.arena.nodes,
+            cache: vec![ptr::null_mut(); val.arena.nodes.len()],
+            keys: HashMap::new(),
+        };
+
+        let mut obj = ptr::null_mut();
+        sys::napi_create_object(env, &mut obj);
+
+        let performance = materializer.string(&val.performance);
+        let performance_key = materializer.string("performance");
+        sys::napi_set_property(env, obj, performance_key, performance);
+
+        let result = materializer.value(val.result_root)?;
+        let result_key = materializer.string("result");
+        sys::napi_set_property(env, obj, result_key, result);
+
+        let trace = match &val.trace {
+            TraceField::None => None,
+            TraceField::Arena(root) => Some(materializer.value(*root)?),
+            TraceField::Json(value) => Some(ToNapiValue::to_napi_value(env, value.clone())?),
+        };
+
+        if let Some(trace) = trace {
+            let trace_key = materializer.string("trace");
+            sys::napi_set_property(env, obj, trace_key, trace);
+        }
+
+        Ok(obj)
+    }
+}

--- a/bindings/nodejs/src/engine.rs
+++ b/bindings/nodejs/src/engine.rs
@@ -11,6 +11,7 @@ use napi_derive::napi;
 use serde_json::Value;
 
 use crate::content::ZenDecisionContent;
+use crate::convert::NodeEvalResponse;
 use crate::custom_node::{CustomNode, CustomNodeTsfn};
 use crate::decision::ZenDecision;
 use crate::dispose::DisposeThreadsafeHandler;
@@ -23,7 +24,9 @@ use crate::safe_result::SafeResult;
 use crate::types::{ZenEngineHandlerRequest, ZenEngineHandlerResponse};
 use zen_engine::loader::{DynamicLoader, LoaderConfig};
 use zen_engine::model::DecisionContent;
-use zen_engine::{DecisionEngine, EvaluationSerializedOptions, EvaluationTraceKind};
+use zen_engine::{
+    DecisionEngine, EvaluationOptions, EvaluationSerializedOptions, EvaluationTraceKind,
+};
 
 #[napi]
 pub struct ZenEngine {
@@ -110,11 +113,21 @@ pub struct EvaluateBatchRequest {
     pub context: Value,
 }
 
-#[napi(object)]
 pub struct EvaluateBatchResult {
     pub success: bool,
-    pub data: Option<Value>,
+    pub data: Option<NodeEvalResponse>,
     pub error: Option<Value>,
+}
+
+impl ToNapiValue for EvaluateBatchResult {
+    unsafe fn to_napi_value(env: napi_env, val: Self) -> napi::Result<napi_value> {
+        let env_wrapper = &Env::from(env);
+        let mut obj = Object::new(env_wrapper)?;
+        obj.set("success", val.success)?;
+        obj.set("data", val.data)?;
+        obj.set("error", val.error)?;
+        Object::to_napi_value(env, obj)
+    }
 }
 
 #[napi(object)]
@@ -240,15 +253,25 @@ impl ZenEngine {
         key: String,
         context: Value,
         opts: Option<ZenEvaluateOptions>,
-    ) -> napi::Result<Value> {
+    ) -> napi::Result<NodeEvalResponse> {
         let graph = self.graph.clone();
         let result = spawn_worker(|| {
-            let options = opts.unwrap_or_default();
+            let serialized: EvaluationSerializedOptions = opts.unwrap_or_default().into();
+            let mode = serialized.trace;
+            let options = EvaluationOptions {
+                trace: mode != EvaluationTraceKind::None,
+                max_depth: serialized.max_depth,
+            };
 
             async move {
                 graph
-                    .evaluate_serialized(key, context.into(), options.into())
+                    .evaluate_with_opts(key, context.into(), options)
                     .await
+                    .map(|response| NodeEvalResponse::build(response, mode))
+                    .map_err(|e| {
+                        e.serialize_with_mode(serde_json::value::Serializer, mode)
+                            .unwrap_or_default()
+                    })
             }
         })
         .await
@@ -301,7 +324,7 @@ impl ZenEngine {
         key: String,
         context: Value,
         opts: Option<ZenEvaluateOptions>,
-    ) -> SafeResult<Value> {
+    ) -> SafeResult<NodeEvalResponse> {
         self.evaluate(key, context, opts).await.into()
     }
 
@@ -312,22 +335,36 @@ impl ZenEngine {
         self.get_decision(key).await.into()
     }
 
-    #[napi]
+    #[napi(
+        ts_return_type = "Promise<Array<{ success: true; data: ZenEngineResponse } | { success: false; error: any }>>"
+    )]
     pub async fn evaluate_batch(
         &self,
         requests: Vec<EvaluateBatchRequest>,
         opts: Option<ZenEvaluateOptions>,
     ) -> napi::Result<Vec<EvaluateBatchResult>> {
         let options: EvaluationSerializedOptions = opts.unwrap_or_default().into();
+        let mode = options.trace;
+        let max_depth = options.max_depth;
 
         let mut handles = Vec::with_capacity(requests.len());
         for req in requests {
             let engine = self.graph.clone();
             let EvaluateBatchRequest { key, context } = req;
             handles.push(spawn_worker(move || async move {
+                let eval_opts = EvaluationOptions {
+                    trace: mode != EvaluationTraceKind::None,
+                    max_depth,
+                };
+
                 engine
-                    .evaluate_serialized(&key, context.into(), options)
+                    .evaluate_with_opts(key, context.into(), eval_opts)
                     .await
+                    .map(|response| NodeEvalResponse::build(response, mode))
+                    .map_err(|e| {
+                        e.serialize_with_mode(serde_json::value::Serializer, mode)
+                            .unwrap_or_default()
+                    })
             }));
         }
 

--- a/bindings/nodejs/src/lib.rs
+++ b/bindings/nodejs/src/lib.rs
@@ -1,5 +1,6 @@
 mod config;
 mod content;
+mod convert;
 mod custom_node;
 mod decision;
 mod dispose;

--- a/bindings/python/src/convert.rs
+++ b/bindings/python/src/convert.rs
@@ -1,0 +1,295 @@
+use std::collections::HashMap;
+use std::rc::Rc;
+
+use pyo3::prelude::{PyDictMethods, PyListMethods};
+use pyo3::types::{PyDict, PyList};
+use pyo3::{Bound, IntoPyObjectExt, Py, PyAny, PyResult, Python};
+use pythonize::pythonize;
+use rust_decimal::prelude::ToPrimitive;
+use rust_decimal::Decimal;
+use serde_json::Value;
+use zen_engine::{DecisionGraphResponse, EvaluationTrace};
+use zen_expression::variable::ToVariable;
+use zen_expression::Variable;
+
+use crate::value::value_to_object;
+
+pub struct VariableConverter<'py> {
+    py: Python<'py>,
+    seen: HashMap<usize, Bound<'py, PyAny>>,
+}
+
+impl<'py> VariableConverter<'py> {
+    pub fn new(py: Python<'py>) -> Self {
+        Self {
+            py,
+            seen: HashMap::new(),
+        }
+    }
+
+    pub fn convert(&mut self, var: &Variable) -> PyResult<Bound<'py, PyAny>> {
+        let addr = match var {
+            Variable::Array(a) => Some(Rc::as_ptr(a) as *const () as usize),
+            Variable::Object(o) => Some(Rc::as_ptr(o) as *const () as usize),
+            _ => None,
+        };
+
+        if let Some(addr) = addr {
+            if let Some(existing) = self.seen.get(&addr) {
+                return Ok(existing.clone());
+            }
+        }
+
+        let built = self.build(var)?;
+        if let Some(addr) = addr {
+            self.seen.insert(addr, built.clone());
+        }
+
+        Ok(built)
+    }
+
+    fn build(&mut self, var: &Variable) -> PyResult<Bound<'py, PyAny>> {
+        match var {
+            Variable::Null => self.py.None().into_bound_py_any(self.py),
+            Variable::Bool(b) => b.into_bound_py_any(self.py),
+            Variable::Number(n) => self.number(*n),
+            Variable::String(s) => s.into_bound_py_any(self.py),
+            Variable::Array(a) => {
+                let list = PyList::empty(self.py);
+                let borrowed = a.borrow();
+                for item in borrowed.iter() {
+                    list.append(self.convert(item)?)?;
+                }
+
+                list.into_bound_py_any(self.py)
+            }
+            Variable::Object(o) => {
+                let dict = PyDict::new(self.py);
+                let borrowed = o.borrow();
+                for (key, value) in borrowed.iter() {
+                    dict.set_item(key.as_ref(), self.convert(value)?)?;
+                }
+
+                dict.into_bound_py_any(self.py)
+            }
+            Variable::Dynamic(d) => Ok(pythonize(self.py, &d.to_value())?),
+        }
+    }
+
+    fn number(&self, n: Decimal) -> PyResult<Bound<'py, PyAny>> {
+        let normalized = n.normalize();
+        if normalized.fract().is_zero() {
+            if let Some(i) = normalized.to_i64() {
+                return i.into_bound_py_any(self.py);
+            }
+
+            if let Some(u) = normalized.to_u64() {
+                return u.into_bound_py_any(self.py);
+            }
+        }
+
+        normalized
+            .to_string()
+            .parse::<f64>()
+            .unwrap_or(f64::NAN)
+            .into_bound_py_any(self.py)
+    }
+}
+
+enum PNode {
+    Null,
+    Bool(bool),
+    Int(i64),
+    Uint(u64),
+    Float(f64),
+    Str(Box<str>),
+    Arr(Vec<u32>),
+    Obj(Vec<(Box<str>, u32)>),
+    Json(Value),
+}
+
+enum PortableTrace {
+    None,
+    Arena(u32),
+    Json(Value),
+}
+
+pub struct PortableResponse {
+    performance: String,
+    nodes: Vec<PNode>,
+    result_root: u32,
+    trace: PortableTrace,
+}
+
+impl PortableResponse {
+    pub fn build(response: DecisionGraphResponse) -> Self {
+        let mut nodes = Vec::new();
+        let mut memo = HashMap::new();
+
+        let result_root = Self::add(&mut nodes, &mut memo, &response.result);
+
+        let trace = match response.trace {
+            None => PortableTrace::None,
+            Some(EvaluationTrace::Graph(graph)) => {
+                PortableTrace::Arena(Self::add(&mut nodes, &mut memo, &graph.to_variable()))
+            }
+            Some(EvaluationTrace::Policy(policy)) => {
+                PortableTrace::Json(serde_json::to_value(&policy).unwrap_or_default())
+            }
+        };
+
+        Self {
+            performance: response.performance,
+            nodes,
+            result_root,
+            trace,
+        }
+    }
+
+    fn add(nodes: &mut Vec<PNode>, memo: &mut HashMap<usize, u32>, var: &Variable) -> u32 {
+        let addr = match var {
+            Variable::Array(a) => Some(Rc::as_ptr(a) as *const () as usize),
+            Variable::Object(o) => Some(Rc::as_ptr(o) as *const () as usize),
+            _ => None,
+        };
+
+        if let Some(addr) = addr {
+            if let Some(id) = memo.get(&addr) {
+                return *id;
+            }
+        }
+
+        let node = match var {
+            Variable::Null => PNode::Null,
+            Variable::Bool(b) => PNode::Bool(*b),
+            Variable::Number(n) => {
+                let normalized = n.normalize();
+                if normalized.fract().is_zero() {
+                    if let Some(i) = normalized.to_i64() {
+                        PNode::Int(i)
+                    } else if let Some(u) = normalized.to_u64() {
+                        PNode::Uint(u)
+                    } else {
+                        PNode::Float(normalized.to_string().parse::<f64>().unwrap_or(f64::NAN))
+                    }
+                } else {
+                    PNode::Float(normalized.to_string().parse::<f64>().unwrap_or(f64::NAN))
+                }
+            }
+            Variable::String(s) => PNode::Str(Box::from(s.as_ref())),
+            Variable::Array(a) => {
+                let borrowed = a.borrow();
+                let mut children = Vec::with_capacity(borrowed.len());
+                for item in borrowed.iter() {
+                    children.push(Self::add(nodes, memo, item));
+                }
+
+                PNode::Arr(children)
+            }
+            Variable::Object(o) => {
+                let borrowed = o.borrow();
+                let mut entries = Vec::with_capacity(borrowed.len());
+                for (key, value) in borrowed.iter() {
+                    let child = Self::add(nodes, memo, value);
+                    entries.push((Box::from(key.as_ref()), child));
+                }
+
+                PNode::Obj(entries)
+            }
+            Variable::Dynamic(d) => PNode::Json(d.to_value()),
+        };
+
+        let id = nodes.len() as u32;
+        nodes.push(node);
+        if let Some(addr) = addr {
+            memo.insert(addr, id);
+        }
+
+        id
+    }
+
+    fn materialize<'py>(
+        &self,
+        py: Python<'py>,
+        id: u32,
+        cache: &mut [Option<Bound<'py, PyAny>>],
+    ) -> PyResult<Bound<'py, PyAny>> {
+        if let Some(existing) = &cache[id as usize] {
+            return Ok(existing.clone());
+        }
+
+        let built = match &self.nodes[id as usize] {
+            PNode::Null => py.None().into_bound_py_any(py)?,
+            PNode::Bool(b) => b.into_bound_py_any(py)?,
+            PNode::Int(i) => i.into_bound_py_any(py)?,
+            PNode::Uint(u) => u.into_bound_py_any(py)?,
+            PNode::Float(f) => f.into_bound_py_any(py)?,
+            PNode::Str(s) => s.into_bound_py_any(py)?,
+            PNode::Arr(children) => {
+                let list = PyList::empty(py);
+                for child in children {
+                    list.append(self.materialize(py, *child, cache)?)?;
+                }
+
+                list.into_bound_py_any(py)?
+            }
+            PNode::Obj(entries) => {
+                let dict = PyDict::new(py);
+                for (key, child) in entries {
+                    dict.set_item(key.as_ref(), self.materialize(py, *child, cache)?)?;
+                }
+
+                dict.into_bound_py_any(py)?
+            }
+            PNode::Json(value) => value_to_object(py, value)?,
+        };
+
+        cache[id as usize] = Some(built.clone());
+        Ok(built)
+    }
+
+    pub fn into_py(self, py: Python<'_>) -> PyResult<Py<PyAny>> {
+        let mut cache = vec![None; self.nodes.len()];
+        let dict = PyDict::new(py);
+
+        dict.set_item("performance", &self.performance)?;
+        dict.set_item(
+            "result",
+            self.materialize(py, self.result_root, &mut cache)?,
+        )?;
+
+        match &self.trace {
+            PortableTrace::None => {}
+            PortableTrace::Arena(root) => {
+                dict.set_item("trace", self.materialize(py, *root, &mut cache)?)?;
+            }
+            PortableTrace::Json(value) => {
+                dict.set_item("trace", value_to_object(py, value)?)?;
+            }
+        }
+
+        Ok(dict.into_any().unbind())
+    }
+}
+
+pub fn response_to_py(py: Python<'_>, response: DecisionGraphResponse) -> PyResult<Py<PyAny>> {
+    let mut converter = VariableConverter::new(py);
+    let dict = PyDict::new(py);
+
+    dict.set_item("performance", response.performance)?;
+    dict.set_item("result", converter.convert(&response.result)?)?;
+
+    if let Some(trace) = response.trace {
+        let trace_obj = match trace {
+            EvaluationTrace::Graph(graph) => converter.convert(&graph.to_variable())?,
+            EvaluationTrace::Policy(policy) => {
+                let value = serde_json::to_value(&policy).unwrap_or_default();
+                value_to_object(py, &value)?
+            }
+        };
+
+        dict.set_item("trace", trace_obj)?;
+    }
+
+    Ok(dict.into_any().unbind())
+}

--- a/bindings/python/src/decision.rs
+++ b/bindings/python/src/decision.rs
@@ -5,7 +5,7 @@ use crate::mt::worker_pool;
 use crate::value::PyValue;
 use crate::variable::PyVariable;
 use anyhow::{anyhow, Context};
-use pyo3::{pyclass, pymethods, IntoPyObjectExt, Py, PyAny, PyResult, Python};
+use pyo3::{pyclass, pymethods, Py, PyAny, PyResult, Python};
 use pyo3_async_runtimes::tokio;
 use pyo3_async_runtimes::tokio::get_current_locals;
 use pyo3_async_runtimes::tokio::re_exports::runtime::Runtime;
@@ -41,8 +41,7 @@ impl PyZenDecision {
                 anyhow!(serde_json::to_string(e.as_ref()).unwrap_or_else(|_| e.to_string()))
             })?;
 
-        let value = serde_json::to_value(&result).context("Fail")?;
-        PyValue(value).into_py_any(py)
+        crate::convert::response_to_py(py, result)
     }
 
     #[pyo3(signature = (ctx, opts=None))]
@@ -57,21 +56,20 @@ impl PyZenDecision {
 
         let decision = self.0.clone();
         let result = tokio::future_into_py_with_locals(py, get_current_locals(py)?, async move {
-            let value = worker_pool()
+            let response = worker_pool()
                 .spawn_pinned(move || async move {
                     decision
                         .evaluate_with_opts(context.into(), options.into())
                         .await
-                        .map(serde_json::to_value)
+                        .map(crate::convert::PortableResponse::build)
                         .map_err(|e| {
                             anyhow!(serde_json::to_string(&e).unwrap_or_else(|_| e.to_string()))
                         })
                 })
                 .await
-                .context("Failed to join threads")??
-                .context("Failed to serialize result")?;
+                .context("Failed to join threads")??;
 
-            Python::with_gil(|py| PyValue(value).into_py_any(py))
+            Python::with_gil(|py| response.into_py(py))
         })?;
 
         Ok(result.unbind())

--- a/bindings/python/src/engine.rs
+++ b/bindings/python/src/engine.rs
@@ -128,8 +128,7 @@ impl PyZenEngine {
             anyhow!(serde_json::to_string(e.as_ref()).unwrap_or_else(|_| e.to_string()))
         })?;
 
-        let value = serde_json::to_value(&result).context("Failed to serialize result")?;
-        PyValue(value).into_py_any(py)
+        crate::convert::response_to_py(py, result)
     }
 
     #[pyo3(signature = (key, ctx, opts=None))]
@@ -145,12 +144,12 @@ impl PyZenEngine {
 
         let engine = self.engine.clone();
         let result = tokio::future_into_py_with_locals(py, get_current_locals(py)?, async move {
-            let value = worker_pool()
+            let response = worker_pool()
                 .spawn_pinned(move || async move {
                     engine
                         .evaluate_with_opts(key, context.into(), options.into())
                         .await
-                        .map(serde_json::to_value)
+                        .map(crate::convert::PortableResponse::build)
                         .map_err(|e| {
                             anyhow!(
                                 serde_json::to_string(e.as_ref()).unwrap_or_else(|_| e.to_string())
@@ -158,10 +157,9 @@ impl PyZenEngine {
                         })
                 })
                 .await
-                .context("Failed to join threads")??
-                .context("Failed to serialize result")?;
+                .context("Failed to join threads")??;
 
-            Python::with_gil(|py| PyValue(value).into_py_any(py))
+            Python::with_gil(|py| response.into_py(py))
         })?;
 
         Ok(result.unbind())

--- a/bindings/python/src/lib.rs
+++ b/bindings/python/src/lib.rs
@@ -10,6 +10,7 @@ use pyo3::types::PyModule;
 use pyo3::{pymodule, wrap_pyfunction, Bound, PyResult, Python};
 
 mod content;
+mod convert;
 mod custom_node;
 mod decision;
 mod engine;


### PR DESCRIPTION
## Faster Node & Python bindings: direct `Variable` to native conversion

Replaces the `Variable -> serde_json::Value -> JsValue/PyObject` round-trip with a **direct, `Rc`-deduplicated** conversion on every engine/decision eval-output path. Shared sub-trees (huge in traces, where node N's output is node N+1's input) are materialized once and reused.

### Results (vs Rust floor; same machine)
| fixture | node | python |
|---|---|---|
| `expression-table-map` +trace | 18.6ms -> 3.1ms (**6.0x**) | 11.1ms -> 2.1ms (**5.4x**) |
| `dynamic-shipping` +trace | 29.2ms -> 4.4ms (**6.6x**) | 16.9ms -> 2.6ms (**6.5x**) |
| `customer-eligibility` +trace | 21.4ms -> 2.6ms (**8.3x**) | 12.7ms -> 1.7ms (**7.4x**) |
| heavy graphs (no trace) | 1.3-1.5x | 1.7-1.8x |

### What's in here
- Direct converters for **all** eval paths: Node `evaluate` / `safeEvaluate` / `evaluateBatch`, Python sync + async `evaluate` (engine + decision).
- Same-thread (Python sync) = direct `Variable -> PyObject`; cross-thread (Node, Python async) = `Send` dedup arena built on the worker, materialized with handle reuse on the JS/GIL thread (`Variable` is `!Send`).
- **New: Python `evaluate_batch` + `async_evaluate_batch`** (parity with Node), parallel, returns `[{success, data, error}]`.
- **New: Python CI test job** (ubuntu+macos x py3.9/3.13); `release` now gated on it.